### PR TITLE
Fix target attribution normalization, optional attribute EOS

### DIFF
--- a/inseq/models/attribution_model.py
+++ b/inseq/models/attribution_model.py
@@ -113,6 +113,7 @@ class AttributionModel(ABC):
         output_step_attributions: bool = False,
         attribute_target: bool = False,
         output_step_probabilities: bool = False,
+        include_eos_baseline: bool = True,
         device: Optional[str] = None,
         **kwargs,
     ) -> OneOrMoreFeatureAttributionSequenceOutputsWithStepOutputs:
@@ -144,6 +145,7 @@ class AttributionModel(ABC):
             output_step_attributions=output_step_attributions,
             attribute_target=attribute_target,
             output_step_probabilities=output_step_probabilities,
+            include_eos_baseline=include_eos_baseline,
             **attribution_args,
         )
         if device is not None:

--- a/inseq/models/huggingface_model.py
+++ b/inseq/models/huggingface_model.py
@@ -170,9 +170,10 @@ class HuggingfaceModel(AttributionModel):
     def encode(
         self,
         texts: TextInput,
-        as_targets: Optional[bool] = False,
-        prepend_bos_token: Optional[bool] = True,
-        return_baseline: Optional[bool] = False,
+        as_targets: bool = False,
+        prepend_bos_token: bool = True,
+        return_baseline: bool = False,
+        include_eos_baseline: bool = True,
     ) -> BatchEncoding:
         """Encode one or multiple texts, producing a BatchEncoding
 
@@ -199,7 +200,10 @@ class HuggingfaceModel(AttributionModel):
             ).to(self.device)
         baseline_ids = None
         if return_baseline:
-            baseline_ids = batch["input_ids"].ne(self.eos_id).long() * self.pad_id
+            if include_eos_baseline:
+                baseline_ids = torch.ones_like(batch["input_ids"]).long() * self.pad_id
+            else:
+                baseline_ids = batch["input_ids"].ne(self.eos_id).long() * self.pad_id
         # We prepend a BOS token only when tokenizing target texts.
         if as_targets and prepend_bos_token:
             ones_mask = torch.ones((batch["input_ids"].shape[0], 1), device=self.device, dtype=long)

--- a/inseq/utils/__init__.py
+++ b/inseq/utils/__init__.py
@@ -13,7 +13,7 @@ from .misc import (
     rgetattr,
 )
 from .registry import Registry, get_available_methods
-from .torch_utils import euclidean_distance, logits2probs, remap_from_filtered, sum_normalize
+from .torch_utils import euclidean_distance, logits2probs, remap_from_filtered, sum_normalize_attributions
 
 
 __all__ = [
@@ -32,7 +32,7 @@ __all__ = [
     "extract_signature_args",
     "remap_from_filtered",
     "drop_padding",
-    "sum_normalize",
+    "sum_normalize_attributions",
     "logits2probs",
     "euclidean_distance",
     "Registry",


### PR DESCRIPTION
## Description

- Fixed a bug in the implementation of target-side attribution in which normalization was applied separately to source and target context, instead of jointly.

- Added a parameter `include_eos_baseline` to the `attribute` method to control whether the EOS token of the source should be considered for feature attribution methods requiring a baseline. As of now, it was ignored by default.
