### PR TITLE
Conversion to nn.Module & Softmax added in forward

### DIFF
--- a/inseq/attr/feat/feature_attribution.py
+++ b/inseq/attr/feat/feature_attribution.py
@@ -43,8 +43,8 @@ from ...utils import (
     extract_signature_args,
     find_char_indexes,
     get_available_methods,
-    logits2probs,
     pretty_tensor,
+    probits2probs,
 )
 from ...utils.typing import ModelIdentifier, TargetIdsTensor
 from ..attribution_decorators import set_hook, unset_hook
@@ -538,7 +538,7 @@ class FeatureAttribution(Registry):
                 batch.sources.attention_mask,
                 batch.targets.attention_mask,
                 # Defines how to treat source and target tensors
-                # Maps on the use_embeddings argument of score_func
+                # Maps on the use_embeddings argument of forward
                 not self.is_layer_attribution,
             ),
         }
@@ -556,14 +556,14 @@ class FeatureAttribution(Registry):
         """
         if self.attribution_model is None:
             raise ValueError("Attribution model is not set.")
-        logits = self.attribution_model.score_func(
+        probits = self.attribution_model(
             encoder_tensors=batch.sources.input_embeds,
             decoder_embeds=batch.targets.input_embeds,
             encoder_attention_mask=batch.sources.attention_mask,
             decoder_attention_mask=batch.targets.attention_mask,
             use_embeddings=True,
         )
-        return logits2probs(logits, target_ids)
+        return probits2probs(probits, target_ids)
 
     @abstractmethod
     def attribute_step(

--- a/inseq/attr/feat/gradient_attribution.py
+++ b/inseq/attr/feat/gradient_attribution.py
@@ -128,11 +128,9 @@ class DeepLiftAttribution(GradientAttribution):
     method_name = "deeplift"
 
     def __init__(self, attribution_model, **kwargs):
-        from ...models import HookableModelWrapper
-
         super().__init__(attribution_model)
         multiply_by_inputs = kwargs.pop("multiply_by_inputs", True)
-        self.method = DeepLift(HookableModelWrapper(self.attribution_model), multiply_by_inputs)
+        self.method = DeepLift(self.attribution_model, multiply_by_inputs)
         self.use_baseline = True
 
 
@@ -149,7 +147,7 @@ class DiscretizedIntegratedGradientsAttribution(GradientAttribution):
         multiply_by_inputs = kwargs.pop("multiply_by_inputs", True)
         self.attribution_model = attribution_model
         self.method = DiscretetizedIntegratedGradients(
-            self.attribution_model.score_func,
+            self.attribution_model,
             multiply_by_inputs,
         )
         self.hook(**kwargs)
@@ -221,7 +219,7 @@ class IntegratedGradientsAttribution(GradientAttribution):
     def __init__(self, attribution_model, **kwargs):
         super().__init__(attribution_model)
         multiply_by_inputs = kwargs.pop("multiply_by_inputs", True)
-        self.method = IntegratedGradients(self.attribution_model.score_func, multiply_by_inputs)
+        self.method = IntegratedGradients(self.attribution_model, multiply_by_inputs)
         self.use_baseline = True
 
 
@@ -236,7 +234,7 @@ class InputXGradientAttribution(GradientAttribution):
 
     def __init__(self, attribution_model):
         super().__init__(attribution_model)
-        self.method = InputXGradient(self.attribution_model.score_func)
+        self.method = InputXGradient(self.attribution_model)
 
 
 class SaliencyAttribution(GradientAttribution):
@@ -250,7 +248,7 @@ class SaliencyAttribution(GradientAttribution):
 
     def __init__(self, attribution_model):
         super().__init__(attribution_model)
-        self.method = Saliency(self.attribution_model.score_func)
+        self.method = Saliency(self.attribution_model)
 
 
 # Layer methods
@@ -272,7 +270,7 @@ class LayerIntegratedGradientsAttribution(GradientAttribution):
         self.hook(**kwargs)
         multiply_by_inputs = kwargs.pop("multiply_by_inputs", True)
         self.method = LayerIntegratedGradients(
-            self.attribution_model.score_func,
+            self.attribution_model,
             self.target_layer,
             multiply_by_inputs=multiply_by_inputs,
         )
@@ -294,7 +292,7 @@ class LayerGradientXActivationAttribution(GradientAttribution):
         self.hook(**kwargs)
         multiply_by_inputs = kwargs.pop("multiply_by_inputs", True)
         self.method = LayerGradientXActivation(
-            self.attribution_model.score_func,
+            self.attribution_model,
             self.target_layer,
             multiply_by_inputs=multiply_by_inputs,
         )
@@ -310,15 +308,13 @@ class LayerDeepLiftAttribution(GradientAttribution):
     method_name = "layer_deeplift"
 
     def __init__(self, attribution_model, **kwargs):
-        from ...models import HookableModelWrapper
-
         super().__init__(attribution_model, hook_to_model=False)
         self.is_layer_attribution = True
         self.use_baseline = True
         self.hook(**kwargs)
         multiply_by_inputs = kwargs.pop("multiply_by_inputs", True)
         self.method = LayerDeepLift(
-            HookableModelWrapper(self.attribution_model),
+            self.attribution_model,
             self.target_layer,
             multiply_by_inputs=multiply_by_inputs,
         )

--- a/inseq/models/__init__.py
+++ b/inseq/models/__init__.py
@@ -1,4 +1,4 @@
-from .attribution_model import AttributionModel, HookableModelWrapper, load_model
+from .attribution_model import AttributionModel, load_model
 from .huggingface_model import HuggingfaceModel
 
 
@@ -6,5 +6,4 @@ __all__ = [
     "AttributionModel",
     "HuggingfaceModel",
     "load_model",
-    "HookableModelWrapper",
 ]

--- a/inseq/utils/__init__.py
+++ b/inseq/utils/__init__.py
@@ -13,7 +13,7 @@ from .misc import (
     rgetattr,
 )
 from .registry import Registry, get_available_methods
-from .torch_utils import euclidean_distance, logits2probs, remap_from_filtered, sum_normalize_attributions
+from .torch_utils import euclidean_distance, probits2probs, remap_from_filtered, sum_normalize_attributions
 
 
 __all__ = [
@@ -33,7 +33,7 @@ __all__ = [
     "remap_from_filtered",
     "drop_padding",
     "sum_normalize_attributions",
-    "logits2probs",
+    "probits2probs",
     "euclidean_distance",
     "Registry",
     "INSEQ_HOME_CACHE",

--- a/inseq/utils/torch_utils.py
+++ b/inseq/utils/torch_utils.py
@@ -61,13 +61,12 @@ def euclidean_distance(vec_a: torch.Tensor, vec_b: torch.Tensor) -> float:
 
 
 @torch.no_grad()
-def logits2probs(logits: FullLogitsTensor, target_ids: TargetIdsTensor) -> TopProbabilitiesTensor:
+def probits2probs(probits: FullLogitsTensor, target_ids: TargetIdsTensor) -> TopProbabilitiesTensor:
     """
-    Compute the scores of the target_ids from the logits.
+    Compute the scores of the target_ids from the probits.
     The scores are computed as the probabilities of the target_ids after softmax.
     """
-    softmax_out = torch.nn.functional.softmax(logits, dim=-1)
-    target_ids = target_ids.reshape(logits.shape[0], 1)
-    # Extracts the ith score from the softmax output over the vocabulary (dim -1 of the logits)
+    target_ids = target_ids.reshape(probits.shape[0], 1)
+    # Extracts the ith score from the softmax output over the vocabulary (dim -1 of the probits)
     # where i is the value of the corresponding index in target_ids.
-    return softmax_out.gather(-1, target_ids).squeeze(-1)
+    return probits.gather(-1, target_ids).squeeze(-1)

--- a/tests/utils/test_torch_utils.py
+++ b/tests/utils/test_torch_utils.py
@@ -21,9 +21,9 @@ def test_pretty_tensor(tensor: torch.Tensor, output: str) -> None:
     assert pretty_tensor(tensor).startswith(output)
 
 
-def test_logits2probs():
+def test_probits2probs():
     # Test with batch of size > 1
-    logits = torch.stack(
+    probits = torch.stack(
         [
             torch.arange(0, 30000, 1.0),
             torch.arange(30000, 60000, 1.0),
@@ -32,19 +32,17 @@ def test_logits2probs():
         ]
     )
     target_ids = torch.tensor([10, 77, 999, 1765]).unsqueeze(-1)
-    # We omit the softmax for the test to check the conformity of the outputs.
-    # In any case, the softmax only affects values and not shape.
-    probs = torch.gather(logits, -1, target_ids.T)
+    probs = torch.gather(probits, -1, target_ids.T)
     assert probs.shape == (1, 4)
     assert torch.eq(probs, torch.tensor([10.0, 77.0, 999.0, 1765.0])).all()
 
     # Test with batch of size 1
-    logits = torch.stack(
+    probits = torch.stack(
         [
             torch.arange(0, 30000, 1.0),
         ]
     )
     target_ids = torch.tensor([23456]).unsqueeze(-1)
-    probs = torch.gather(logits, -1, target_ids.T)
+    probs = torch.gather(probits, -1, target_ids.T)
     assert probs.shape == (1, 1)
     assert torch.eq(probs, torch.tensor([23456.0])).all()


### PR DESCRIPTION
## Description

- The `AttributionModel` and child classes are now `torch.nn.Module`. Consequently, `score_func` becomes the regular `forward` method, simplifying the code in the attribution methods and enabling us to eliminate the `HookableModelWrapper` class.

- Following [some](https://github.com/mt-upc/transformer-contributions/blob/main/src/contributions.py) [examples](https://github.com/mt-upc/transformer-contributions/blob/main/src/contributions.py), the output of the forward function of `HuggingfaceModel` is passed through a `torch.softmax` function. The effect of this operation is an increased sparsity in the saliency patterns, although most salient trends are preserved.
