### PR TITLE
Fix conflicting generation args

### DIFF
--- a/docs/source/_static/inseq.js
+++ b/docs/source/_static/inseq.js
@@ -61,15 +61,11 @@ function resizeHtmlExamples() {
     for (const ex of examples) {
         const iframe = ex.firstElementChild;
         const zoom = iframe.getAttribute("scale")
-        const origHeight = iframe.contentWindow.document.body.scrollHeight
-        const origWidth = iframe.contentWindow.document.body.scrollWidth
-        ex.style.height = ((origHeight * zoom) + 50) + "px";
-        const frameHeight = origHeight / zoom
-        const frameWidth = origWidth / zoom
+        ex.style.height = ((iframe.contentWindow.document.body.scrollHeight * zoom) + 50) + "px";
         // add extra 50 pixels - in reality need just a bit more
-        iframe.style.height = frameHeight + "px"
+        iframe.style.height = (iframe.contentWindow.document.body.scrollHeight / zoom) + "px"
         // set the width of the iframe as the width of the iframe content
-        iframe.style.width = frameWidth + 'px';
+        iframe.style.width = (iframe.contentWindow.document.body.scrollWidth / zoom) + 'px';
         iframe.style.zoom = zoom;
         iframe.style.MozTransform = `scale(${zoom})`;
         iframe.style.WebkitTransform = `scale(${zoom})`;
@@ -83,12 +79,14 @@ function resizeHtmlExamples() {
 function onLoad() {
     addIcon();
     addCustomFooter();
+    resizeHtmlExamples();
 }
 
 window.addEventListener("load", onLoad);
 window.onresize = function() {
     var wwidth = $(window).width();
-    if(curr_width!==wwidth){
-        resizeHtmlExamples();
+    if( curr_width !== wwidth ){
+        window.location.reload();
+        curr_width = wwidth;
     }
 }


### PR DESCRIPTION
## Description

As highlighted in huggingface/transformers#20825 the default setting for `max_new_tokens` in the `HuggingfaceModel` class was causing some problems with generation due to conflicts between `max_new_tokens` and `max_length` in :hugs: transformers. For example:

```python
import inseq

model = inseq.load_model("facebook/wmt19-en-de", "integrated_gradients")
out = model.attribute("The developer argued with the designer because her idea cannot be implemented.")
```

would produce the error

```shell
ValueError: Both `max_new_tokens` and `max_length` have been set but they serve the same purpose -- setting a limit to the generated output length. Remove one of those arguments. Please refer to the documentation for more information. 
(https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)
```

The behavior was fixed by removing the default setting in inseq and letting :hugs: transformers handle the setting entirely via kwargs. This will produce some warnings when generating e.g. with `gpt2`, but those do not pertain to inseq but rather to transformers.

Attribute maps resizing when resizing doc windows was also corrected.