### PR TITLE
Fix EOS baseline for models with `pad_token_id` != 0

### DIFF
--- a/inseq/models/huggingface_model.py
+++ b/inseq/models/huggingface_model.py
@@ -257,7 +257,9 @@ class HuggingfaceModel(AttributionModel):
             if include_eos_baseline:
                 baseline_ids = torch.ones_like(batch["input_ids"]).long() * self.tokenizer.unk_token_id
             else:
-                baseline_ids = batch["input_ids"].ne(self.eos_token_id).long() * self.tokenizer.unk_token_id
+                baseline_ids_non_eos = batch["input_ids"].ne(self.eos_token_id).long() * self.tokenizer.unk_token_id
+                baseline_ids_eos = batch["input_ids"].eq(self.eos_token_id).long() * self.eos_token_id
+                baseline_ids = baseline_ids_non_eos + baseline_ids_eos
         # We prepend a BOS token only when tokenizing target texts.
         if as_targets and self.is_encoder_decoder:
             ones_mask = torch.ones((batch["input_ids"].shape[0], 1), device=self.device, dtype=long)


### PR DESCRIPTION
## Description

Currently, when using attribution methods requiring baselines (e.g. `integrated_gradients`) the default behavior is to exclude the source end-of-string token from the attribution by setting it to the same index in the baseline. This setting was however assuming that the EOS token id was always 0, which is not the case for most models, producing unwanted attributions on the EOS token. This PR fixes this behavior by ensuring that the correct token id is set in the baseline for the EOS.