### PR TITLE
Target prefix-constrained generation

### DIFF
--- a/inseq/attr/feat/feature_attribution.py
+++ b/inseq/attr/feat/feature_attribution.py
@@ -19,7 +19,7 @@ Todo:
 import logging
 from abc import abstractmethod
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from torchtyping import TensorType
 from transformers import set_seed
@@ -150,7 +150,7 @@ class FeatureAttribution(Registry):
     @batched
     def prepare_and_attribute(
         self,
-        sources: Sequence[str],
+        sources: FeatureAttributionInput,
         targets: FeatureAttributionInput,
         attr_pos_start: Optional[int] = None,
         attr_pos_end: Optional[int] = None,
@@ -172,9 +172,9 @@ class FeatureAttribution(Registry):
         and the :meth:`~inseq.models.AttributionModel.prepare_inputs_for_attribution` method.
 
         Args:
-            sources (:obj:`list(str)`): The sources provided to the
+            sources (:obj:`FeatureAttributionInput`): The sources provided to the
                 :meth:`~inseq.attr.feat.FeatureAttribution.prepare` method.
-            targets (:obj:`FeatureAttributionInput): The targets provided to the
+            targets (:obj:`FeatureAttributionInput`): The targets provided to the
                 :meth:`~inseq.attr.feat.FeatureAttribution.prepare` method.
             attr_pos_start (:obj:`int`, `optional`): The initial position for performing
                 sequence attribution. Defaults to 0.

--- a/inseq/commands/attribute.py
+++ b/inseq/commands/attribute.py
@@ -26,6 +26,17 @@ class AttributeBaseArgs:
             "help": "Performs the attribution procedure including the generated prefix at every step.",
         },
     )
+    generate_from_target_prefix: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether the ``generated_texts`` should be used as"
+                "target prefixes for the generation process. If False, the ``generated_texts`` will be used as full"
+                "targets. This option is only available for encoder-decoder models, since the same behavior can be"
+                "achieved by modifying the input texts for decoder-only models. Default: False."
+            )
+        },
+    )
     step_scores: List[str] = field(
         default_factory=list, metadata={"help": "Adds step scores to the attribution output."}
     )
@@ -165,6 +176,7 @@ def attribute(input_texts, generated_texts, args: AttributeBaseArgs):
         generation_args={"max_new_tokens": args.max_gen_length},
         attr_pos_start=args.start_pos,
         attr_pos_end=args.end_pos,
+        generate_from_target_prefix=args.generate_from_target_prefix,
     )
     if args.viz_path:
         print(f"Saving visualization to {args.viz_path}")


### PR DESCRIPTION
## Description

This PR introduces a `generate_from_target_prefix` argument in the `model.attribute` method and the `inseq attribute` CLI, allowing the usage of pre-specified `generated_text` as a prefix for the model to complete, rather than a finished generation.

This functionality exploits the capabilities of the `generate` function in :hugs: transformers, and is restricted to encoder-decoder models only, since controlling the prefix is handled through the `input_text` parameter for decoder-only models. The same behavior could already be achieved in inseq v0.4 by providing explicit `decoder_input_ids`  as `generation_args`.

**Current behavior:**

```python
>>> import inseq

>>> m = inseq.load_model("Helsinki-NLP/opus-mt-en-it", "saliency")
>>> prefix_ids = m.encode("Hey mondo!", as_targets=True)
>>> out = model.attribute(
...	   "Hello world! My name is Inseq",
...	   generation_args={"decoder_input_ids": prefix_ids.input_ids}
...)
>>> out.info["generated_texts"]
['Hey mondo! mi chiamo Inseq.']
```

**New behavior using `generate_from_target_prefix`:**

```python
>>> import inseq

>>> m = inseq.load_model("Helsinki-NLP/opus-mt-en-it", "saliency")
>>> out = model.attribute(
...    "Hello world! My name is Inseq",
...    "Hey mondo!",
...    generate_from_target_prefix=True
... )
>>> out.info["generated_texts"]
['Hey mondo! mi chiamo Inseq.']
```

The new argument also works with batched inputs. Setting the target prefix to an empty string will perform the fully unconstrained generation, as if no prefix was provided:

```python
>>> import inseq

>>> model = inseq.load_model("Helsinki-NLP/opus-mt-en-it", "saliency")
>>> src = ["Hello world! My name is Inseq", "I love bugging around code all day"]
>>> prefix = ["Hey mondo!", ""]
>>> out = model.attribute(src, prefix, generate_from_target_prefix=True)
>>> out.info["generated_texts"]
... ['Hey mondo! mi chiamo Inseq', 'Adoro le cimici intorno al codice tutto il giorno']
```

## Type of Change

- 🚀 New feature (non-breaking change which adds functionality)
