### PR TITLE
Fix `get_scores_dicts` for non-initial `attr_pos_start`

### DIFF
--- a/tests/data/test_attribution.py
+++ b/tests/data/test_attribution.py
@@ -6,7 +6,12 @@ from inseq import FeatureAttributionOutput, load_model
 
 @fixture(scope="session")
 def saliency_mt_model():
-    return load_model("Helsinki-NLP/opus-mt-en-it", "saliency", device="cpu")
+    return load_model("Helsinki-NLP/opus-mt-en-it", "saliency")
+
+
+@fixture(scope="session")
+def saliency_gpt2_model_tiny():
+    return load_model("hf-internal-testing/tiny-random-GPT2LMHeadModel", "saliency")
 
 
 def test_save_load_attribution(tmp_path, saliency_mt_model):
@@ -34,3 +39,24 @@ def test_save_load_attribution_compressed(tmp_path, saliency_mt_model):
     out.save(out_path, compress=True)
     loaded_out = FeatureAttributionOutput.load(out_path, decompress=True)
     assert out == loaded_out
+
+
+def test_get_scores_dicts_encoder_decoder(saliency_mt_model):
+    out = saliency_mt_model.attribute(["This is a test.", "Hello world!"], device="cpu", show_progress=False)
+    dicts = out.get_scores_dicts()
+    assert len(dicts) == 2
+    assert isinstance(dicts[0], dict) and isinstance(dicts[1], dict)
+    assert "source_attributions" in dicts[0] and "target_attributions" in dicts[0] and "step_scores" in dicts[0]
+
+
+def test_get_scores_dicts_decoder_only(saliency_gpt2_model_tiny):
+    out = saliency_gpt2_model_tiny.attribute(
+        ["This is a test", "Hello world!"],
+        ["This is a test generation", "Hello world! Today is a beautiful day."],
+        show_progress=False,
+        device="cpu",
+    )
+    dicts = out.get_scores_dicts()
+    assert len(dicts) == 2
+    assert isinstance(dicts[0], dict) and isinstance(dicts[1], dict)
+    assert "source_attributions" in dicts[0] and "target_attributions" in dicts[0] and "step_scores" in dicts[0]


### PR DESCRIPTION
## Description

Fixes exporting `get_scores_dicts` for generations starting at non-initial positions (i.e. when `attr_pos_start != 0`, like for decoder-only models), reported broken by #185 

## Type of Change

- 🔧 Bug fix (non-breaking change which fixes an issue)
