### PR TITLE
Fix `get_scores_dict` for duplicate tokens

### DIFF
--- a/inseq/data/attribution.py
+++ b/inseq/data/attribution.py
@@ -324,22 +324,22 @@ class FeatureAttributionSequenceOutput(TensorWrapper, AggregableMixin):
         for tgt_idx in range(aggr.attr_pos_start, aggr.attr_pos_end):
             tgt_tok = aggr.target[tgt_idx]
             if aggr.source_attributions is not None:
-                return_dict["source_attributions"][tgt_tok.token] = {}
+                return_dict["source_attributions"][(tgt_idx, tgt_tok.token)] = {}
                 for src_idx, src_tok in enumerate(aggr.source):
-                    return_dict["source_attributions"][tgt_tok.token][src_tok.token] = aggr.source_attributions[
-                        src_idx, tgt_idx - aggr.attr_pos_start
-                    ].item()
+                    return_dict["source_attributions"][(tgt_idx, tgt_tok.token)][(src_idx, src_tok.token)] = (
+                        aggr.source_attributions[src_idx, tgt_idx - aggr.attr_pos_start].item()
+                    )
             if aggr.target_attributions is not None:
-                return_dict["target_attributions"][tgt_tok.token] = {}
+                return_dict["target_attributions"][(tgt_idx, tgt_tok.token)] = {}
                 for tgt_idx_attr in range(aggr.attr_pos_end):
                     tgt_tok_attr = aggr.target[tgt_idx_attr]
-                    return_dict["target_attributions"][tgt_tok.token][tgt_tok_attr.token] = aggr.target_attributions[
-                        tgt_idx_attr, tgt_idx - aggr.attr_pos_start
-                    ].item()
+                    return_dict["target_attributions"][(tgt_idx, tgt_tok.token)][
+                        (tgt_idx_attr, tgt_tok_attr.token)
+                    ] = aggr.target_attributions[tgt_idx_attr, tgt_idx - aggr.attr_pos_start].item()
             if aggr.step_scores is not None:
-                return_dict["step_scores"][tgt_tok.token] = {}
+                return_dict["step_scores"][(tgt_idx, tgt_tok.token)] = {}
                 for step_score_id, step_score in aggr.step_scores.items():
-                    return_dict["step_scores"][tgt_tok.token][step_score_id] = step_score[
+                    return_dict["step_scores"][(tgt_idx, tgt_tok.token)][step_score_id] = step_score[
                         tgt_idx - aggr.attr_pos_start
                     ].item()
         return return_dict

--- a/inseq/data/attribution.py
+++ b/inseq/data/attribution.py
@@ -326,9 +326,9 @@ class FeatureAttributionSequenceOutput(TensorWrapper, AggregableMixin):
             if aggr.source_attributions is not None:
                 return_dict["source_attributions"][(tgt_idx, tgt_tok.token)] = {}
                 for src_idx, src_tok in enumerate(aggr.source):
-                    return_dict["source_attributions"][(tgt_idx, tgt_tok.token)][(src_idx, src_tok.token)] = (
-                        aggr.source_attributions[src_idx, tgt_idx - aggr.attr_pos_start].item()
-                    )
+                    return_dict["source_attributions"][(tgt_idx, tgt_tok.token)][
+                        (src_idx, src_tok.token)
+                    ] = aggr.source_attributions[src_idx, tgt_idx - aggr.attr_pos_start].item()
             if aggr.target_attributions is not None:
                 return_dict["target_attributions"][(tgt_idx, tgt_tok.token)] = {}
                 for tgt_idx_attr in range(aggr.attr_pos_end):


### PR DESCRIPTION
## Description

At the moment the presence of duplicate tokens in either the source or the target sentence produces a malformed dictionary when `out.get_scores_dict` is called due to the unicity requirement of dict keys. This PR fixes the issue by using tuples of `token_idx, token` as keys for the different dictionary field.

- 💥 Breaking change (fix or feature that would cause existing functionality to change)
