### PR TITLE
Tokens diff view for contrastive attribution methods

### DIFF
--- a/inseq/attr/feat/attribution_utils.py
+++ b/inseq/attr/feat/attribution_utils.py
@@ -101,9 +101,24 @@ def get_step_scores(
     return STEP_SCORES_MAP[score_identifier](**step_scores_args)
 
 
-def join_token_ids(tokens: OneOrMoreTokenSequences, ids: OneOrMoreIdSequences) -> List[TokenWithId]:
-    """Builds a list of TokenWithId objects from a list of token sequences and a list of id sequences."""
-    return [[TokenWithId(token, id) for token, id in zip(tok_seq, idx_seq)] for tok_seq, idx_seq in zip(tokens, ids)]
+def join_token_ids(
+    tokens: OneOrMoreTokenSequences,
+    ids: OneOrMoreIdSequences,
+    contrast_tokens: Optional[OneOrMoreTokenSequences] = None,
+) -> List[TokenWithId]:
+    """Joins tokens and ids into a list of TokenWithId objects."""
+    if contrast_tokens is None:
+        contrast_tokens = tokens
+    sequences = []
+    for target_tokens_seq, contrast_target_tokens_seq, input_ids_seq in zip(tokens, contrast_tokens, ids):
+        curr_seq = []
+        for token, contrast_token, idx in zip(target_tokens_seq, contrast_target_tokens_seq, input_ids_seq):
+            if token != contrast_token:
+                curr_seq.append(TokenWithId(f"{contrast_token} → {token}", -1))
+            else:
+                curr_seq.append(TokenWithId(token, idx))
+        sequences.append(curr_seq)
+    return sequences
 
 
 def extract_args(

--- a/inseq/utils/misc.py
+++ b/inseq/utils/misc.py
@@ -99,7 +99,7 @@ def pretty_dict(d: Dict[str, Any], lpad: int = 4) -> str:
             out_txt += pretty_tensor(v, lpad + 4)
         elif isinstance(v, dict):
             out_txt += pretty_dict(v, lpad + 4)
-        elif hasattr(v, "to_dict"):
+        elif hasattr(v, "to_dict") and not isinstance(v, type):
             out_txt += f"{v.__class__.__name__}({pretty_dict(v.to_dict(), lpad + 4)})"
         else:
             out_txt += "None" if v is None else str(v)


### PR DESCRIPTION
## Description

This PR adds the `original → contrastive` label currently used in the `PairAggregator` to mark tokens that differ between the original generated sequence and the `contrast_target` when a contrastive `attributed_fn` is used in `model.attribute`. Previously, only the original target was shown. This enables to visually assess whether the alignment of contrastive target pair is correct.

**Example:**

```python
import inseq
import pandas as pd

model = inseq.load_model("Helsinki-NLP/opus-mt-en-it", "saliency")
out = model.attribute(
    "UN peacekeepers",
    "I soldati della pace dell'ONU",
    attributed_fn="contrast_prob_diff",
    contrast_targets="Le forze di pace delle Nazioni Unite"
)
out.show()
```
![image](https://github.com/inseq-team/inseq/assets/16674069/52c3c885-9de0-4f76-ae7d-11739c1cf30a)

- 💥 Breaking change: The `TokenWithId` items in `targets` will now have the new text to mark the contrastive step if they differ from the original when a contrastive step function is used. Their id is set to -1 to represent the fact they do not correspond to real tokens.

