### PR TITLE
Fix attribution remapping for decoder-only models

### DIFF
--- a/inseq/data/attribution.py
+++ b/inseq/data/attribution.py
@@ -387,21 +387,21 @@ class FeatureAttributionStepOutput(TensorWrapper):
             )
         if self.target_attributions is not None:
             self.target_attributions = remap_from_filtered(
-                original_shape=(len(batch.targets.input_tokens), *self.target_attributions.shape[1:]),
+                original_shape=(len(batch.target_tokens), *self.target_attributions.shape[1:]),
                 mask=target_attention_mask,
                 filtered=self.target_attributions,
             )
         if self.step_scores is not None:
             for score_name, score_tensor in self.step_scores.items():
                 self.step_scores[score_name] = remap_from_filtered(
-                    original_shape=(len(batch.targets.input_tokens), 1),
+                    original_shape=(len(batch.target_tokens), 1),
                     mask=target_attention_mask,
                     filtered=score_tensor.unsqueeze(-1),
                 ).squeeze(-1)
         if self.sequence_scores is not None:
             for score_name, score_tensor in self.sequence_scores.items():
                 self.sequence_scores[score_name] = remap_from_filtered(
-                    original_shape=(len(batch.targets.input_tokens), *self.source_attributions.shape[1:]),
+                    original_shape=(len(batch.target_tokens), *self.source_attributions.shape[1:]),
                     mask=target_attention_mask,
                     filtered=score_tensor,
                 )

--- a/tests/fixtures/huggingface_model.json
+++ b/tests/fixtures/huggingface_model.json
@@ -48,5 +48,21 @@
                 "Le idee verdi senza colore dormono furiosamente"
             ]
         ]
+    ],
+    "short_texts_decoder": [
+        [
+            "",
+            "Hello world! Today is a great day."
+        ],
+        [
+            [
+                "",
+                "Colorless green ideas"
+            ],
+            [
+                "Hello world! Today is a great day.",
+                "Colorless green ideas sleep furiously."
+            ]
+        ]
     ]
 }

--- a/tests/models/test_huggingface_model.py
+++ b/tests/models/test_huggingface_model.py
@@ -156,6 +156,29 @@ def test_batched_attribution_consistency_seq2seq(
         )
 
 
+def test_batched_attribution_consistency_decoder_only(saliency_gpt2_model):
+    texts_single, reference_single = EXAMPLES["short_texts_decoder"][0]
+    texts_batch, reference_batch = EXAMPLES["short_texts_decoder"][1]
+    out_single = saliency_gpt2_model.attribute(
+        texts_single,
+        reference_single,
+        show_progress=False,
+        device=get_default_device(),
+    )
+    out_batch = saliency_gpt2_model.attribute(
+        texts_batch,
+        reference_batch,
+        show_progress=False,
+        device=get_default_device(),
+    )
+    assert torch.allclose(
+        out_single.sequence_attributions[0].target_attributions,
+        out_batch.sequence_attributions[0].target_attributions,
+        atol=8e-2,
+        equal_nan=True,
+    )
+
+
 @mark.slow
 @mark.parametrize(("texts", "reference_texts"), EXAMPLES["texts"])
 @mark.parametrize("attribution_method", ATTRIBUTION_METHODS)


### PR DESCRIPTION
## Description

Fixes an incompatibility for decoder-only models in the `remap_from_filtered` method that was producing an error when used with batch_size > 1.
