### PR TITLE
Allow contrastive attribution with shorter contrastive targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,10 @@ Step functions are used to extract custom scores from the model at each step of 
 - `perplexity`: Perplexity of the target token.
 - `contrast_prob`: Probability of the target token when different contrastive inputs are provided to the model. Equivalent to `probability` when no contrastive inputs are provided.
 - `pcxmi`: Point-wise Contextual Cross-Mutual Information (P-CXMI) for the target token given original and contrastive contexts [(Yin et al. 2021)](https://arxiv.org/abs/2109.07446).
-- `kl_divergence`: KL divergence of the predictive distribution given original and contrastive contexts. Can be limited to top-K most likely target token options using the `top_k` parameter.
+- `kl_divergence`: KL divergence of the predictive distribution given original and contrastive contexts. Can be restricted to most likely target token options using the `top_k` and `top_p` parameters.
 - `contrast_prob_diff`: Difference in probability between original and foil target tokens pair, can be used for contrastive evaluation as in [Contrastive Attribution](https://aclanthology.org/2022.emnlp-main.14/) (Yin and Neubig, 2022).
 - `mc_dropout_prob_avg`: Average probability of the target token across multiple samples using [MC Dropout](https://arxiv.org/abs/1506.02142) (Gal and Ghahramani, 2016).
+- `top_p_size`: The number of tokens with cumulative probability greater than `top_p` in the predictive distribution of the model.
 
 The following example computes contrastive attributions using the `contrast_prob_diff` step function:
 

--- a/inseq/attr/feat/attribution_utils.py
+++ b/inseq/attr/feat/attribution_utils.py
@@ -106,7 +106,7 @@ def join_token_ids(
         curr_seq = []
         for pos_idx, (token, token_idx) in enumerate(zip(target_tokens_seq, input_ids_seq)):
             contrast_pos_idx = get_aligned_idx(pos_idx, alignments_seq)
-            if token != contrast_target_tokens_seq[contrast_pos_idx]:
+            if contrast_pos_idx != -1 and token != contrast_target_tokens_seq[contrast_pos_idx]:
                 curr_seq.append(TokenWithId(f"{contrast_target_tokens_seq[contrast_pos_idx]} → {token}", -1))
             else:
                 curr_seq.append(TokenWithId(token, token_idx))

--- a/inseq/attr/feat/feature_attribution.py
+++ b/inseq/attr/feat/feature_attribution.py
@@ -327,6 +327,7 @@ class FeatureAttribution(Registry):
                     contrast_batch.target_tokens, as_targets=as_targets
                 ),
                 special_tokens=self.attribution_model.special_tokens,
+                start_pos=attr_pos_start,
             )
             attributed_fn_args["contrast_targets_alignments"] = contrast_targets_alignments
             if "contrast_targets" in step_scores_args:

--- a/inseq/models/attribution_model.py
+++ b/inseq/models/attribution_model.py
@@ -153,6 +153,7 @@ class InputFormatter:
         contrast_sequences: List[str],
         contrast_tokens: List[List[str]],
         special_tokens: List[str] = [],
+        start_pos: int = 0,
     ) -> Tuple[DecoderOnlyBatch, Optional[List[List[Tuple[int, int]]]]]:
         # Ensure that the contrast_targets_alignments are in the correct format (list of lists of idxs pairs)
         if contrast_targets_alignments:
@@ -180,6 +181,7 @@ class InputFormatter:
                     contrast_tokens=c_tok,
                     fill_missing=True,
                     special_tokens=special_tokens,
+                    start_pos=start_pos,
                 )
             )
         return adjusted_alignments


### PR DESCRIPTION
## Description

At the moment, contrastive attribution cannot be performed using a substring of the original inputs as `contrast_targets`. This is an important limitation since one might want to attribute which parts of the original additional contest is influencing the predictions compared to a contrastive alternative lacking context. To illustrate this issue, in the following example we can see that the token "Jungle" is 41% less likely without the prefix mentioning Guns N' Roses, but we cannot attribute this difference to the prefix since it is not part of the original input:

```python
import inseq

model = inseq.load_model("gpt2", "saliency")

out = model.attribute(
    "Welcome to",
    "Welcome to the Jungle",
	"contrast_prob_diff",
    contrast_target_prefixes="The recent song by Guns N' Roses,",
    step_scores=["probability", "contrast_prob_diff"]
)
out.show()
```

This PR introduces a fix that enables the attribution using the longest string as original input. This behavior can be achieved using `contrast_targets` and `contrast_targets_alignments` as follows:

```python
import inseq

model = inseq.load_model("gpt2", "saliency")

offset = len(model.encode("The recent song by Guns N' Roses, Welcome to").input_tokens[0])

out = model.attribute(
    "The recent song by Guns N' Roses, Welcome to",
    "The recent song by Guns N' Roses, Welcome to the Jungle",
    attr_pos_start=offset - 1,
    contrast_targets = "Welcome to the Jungle",
    contrast_targets_alignments="auto",
    attributed_fn="contrast_prob_diff",
    step_scores=["probability", "contrast_prob_diff"]
)
```

![image](https://github.com/inseq-team/inseq/assets/16674069/a370402b-365b-4789-a174-cd36f2317ce7)


Given the context, the resulting attribution highlights `Roses` and `Welcome` as the main sources driving the increase in probability. The same behavior can be obtained for encoder-decoder models using `contrast_sources` to override the original input source.

:warning: At the moment, contrastive attributions with alignment will work only if a contrastive `attributed_fn` is also employed (i.e. not just passing contrastive `step_scores` functions). To be 100% sure that the contrastive target will be aligned at the end of the sequence, pass explicit index pairs instead of using `contrast_targets_alignments="auto"`.
