### PR TITLE
fix `merge_attributions`

### DIFF
--- a/docs/source/main_classes/main_functions.rst
+++ b/docs/source/main_classes/main_functions.rst
@@ -35,3 +35,5 @@ functionalities required for its usage.
 .. autofunction:: list_aggregation_functions
 
 .. autofunction:: show_attributions
+
+.. autofunction:: merge_attributions

--- a/inseq/__init__.py
+++ b/inseq/__init__.py
@@ -34,4 +34,5 @@ __all__ = [
     "list_step_functions",
     "list_supported_frameworks",
     "register_step_function",
+    "merge_attributions",
 ]

--- a/inseq/__init__.py
+++ b/inseq/__init__.py
@@ -5,6 +5,7 @@ from .data import (
     FeatureAttributionOutput,
     list_aggregation_functions,
     list_aggregators,
+    merge_attributions,
     show_attributions,
 )
 from .models import AttributionModel, list_supported_frameworks, load_model

--- a/inseq/data/__init__.py
+++ b/inseq/data/__init__.py
@@ -21,6 +21,7 @@ from .attribution import (
     GranularFeatureAttributionStepOutput,
     MultiDimensionalFeatureAttributionStepOutput,
     get_batch_from_inputs,
+    merge_attributions,
 )
 from .batch import (
     Batch,
@@ -60,6 +61,7 @@ __all__ = [
     "list_aggregation_functions",
     "MultiDimensionalFeatureAttributionStepOutput",
     "get_batch_from_inputs",
+    "merge_attributions",
     "list_aggregators",
     "slice_batch_from_position",
 ]

--- a/inseq/data/attribution.py
+++ b/inseq/data/attribution.py
@@ -374,9 +374,9 @@ class FeatureAttributionSequenceOutput(TensorWrapper, AggregableMixin):
             if aggr.source_attributions is not None:
                 return_dict["source_attributions"][(tgt_idx, tgt_tok.token)] = {}
                 for src_idx, src_tok in enumerate(aggr.source):
-                    return_dict["source_attributions"][(tgt_idx, tgt_tok.token)][(src_idx, src_tok.token)] = (
-                        aggr.source_attributions[src_idx, tgt_idx - aggr.attr_pos_start].item()
-                    )
+                    return_dict["source_attributions"][(tgt_idx, tgt_tok.token)][
+                        (src_idx, src_tok.token)
+                    ] = aggr.source_attributions[src_idx, tgt_idx - aggr.attr_pos_start].item()
             if aggr.target_attributions is not None:
                 return_dict["target_attributions"][(tgt_idx, tgt_tok.token)] = {}
                 for tgt_idx_attr in range(aggr.attr_pos_end):

--- a/inseq/data/attribution.py
+++ b/inseq/data/attribution.py
@@ -78,10 +78,11 @@ def merge_attributions(attributions: List["FeatureAttributionOutput"]) -> "Featu
     Merging is allowed only if the two outputs match on the fields specified in ``_merge_match_info_fields``.
 
     Args:
-        attributions (`list(FeatureAttributionOutput)`): The FeatureAttributionOutput objects to be merged.
+        attributions (:obj:`list` of :class:`~inseq.data.FeatureAttributionOutput`): The FeatureAttributionOutput
+            objects to be merged.
 
     Returns:
-        `FeatureAttributionOutput`: Merged object
+        :class:`~inseq.data.FeatureAttributionOutput`: Merged object.
     """
     assert all(
         isinstance(x, FeatureAttributionOutput) for x in attributions
@@ -373,9 +374,9 @@ class FeatureAttributionSequenceOutput(TensorWrapper, AggregableMixin):
             if aggr.source_attributions is not None:
                 return_dict["source_attributions"][(tgt_idx, tgt_tok.token)] = {}
                 for src_idx, src_tok in enumerate(aggr.source):
-                    return_dict["source_attributions"][(tgt_idx, tgt_tok.token)][
-                        (src_idx, src_tok.token)
-                    ] = aggr.source_attributions[src_idx, tgt_idx - aggr.attr_pos_start].item()
+                    return_dict["source_attributions"][(tgt_idx, tgt_tok.token)][(src_idx, src_tok.token)] = (
+                        aggr.source_attributions[src_idx, tgt_idx - aggr.attr_pos_start].item()
+                    )
             if aggr.target_attributions is not None:
                 return_dict["target_attributions"][(tgt_idx, tgt_tok.token)] = {}
                 for tgt_idx_attr in range(aggr.attr_pos_end):

--- a/inseq/models/attribution_model.py
+++ b/inseq/models/attribution_model.py
@@ -14,6 +14,7 @@ from ..data import (
     FeatureAttributionInput,
     FeatureAttributionOutput,
     FeatureAttributionStepOutput,
+    merge_attributions,
 )
 from ..utils import (
     MissingAttributionMethodError,
@@ -451,7 +452,7 @@ class AttributionModel(ABC, torch.nn.Module):
             attributed_fn_args=attributed_fn_args,
             step_scores_args=step_scores_args,
         )
-        attribution_output = FeatureAttributionOutput.merge_attributions(attribution_outputs)
+        attribution_output = merge_attributions(attribution_outputs)
         attribution_output.info["input_texts"] = input_texts
         attribution_output.info["generated_texts"] = (
             [generated_texts] if isinstance(generated_texts, str) else generated_texts


### PR DESCRIPTION
## Description

The merge_attributions method is moved out of the FeatureAttributionOutput class as described in #209.

## Related Issue

Fix #209 

## Type of Change

- 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/inseq-team/inseq/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/inseq-team/inseq/blob/master/CONTRIBUTING.md) guide.
- [x] I've successfully run the style checks using `make fix-style`.
- [x] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
