### PR TITLE
Fix tokenization space cleanup

### DIFF
--- a/inseq/models/huggingface_model.py
+++ b/inseq/models/huggingface_model.py
@@ -215,10 +215,7 @@ class HuggingfaceModel(AttributionModel):
             **kwargs,
         )
         sequences = generation_out.sequences
-        texts = self.tokenizer.batch_decode(
-            sequences,
-            skip_special_tokens=True,
-        )
+        texts = self.decode(ids=sequences, skip_special_tokens=True)
         if return_generation_output:
             return texts, generation_out
         return texts
@@ -295,7 +292,11 @@ class HuggingfaceModel(AttributionModel):
         ids: Union[List[int], List[List[int]], IdsTensor],
         skip_special_tokens: bool = True,
     ) -> List[str]:
-        return self.tokenizer.batch_decode(ids, skip_special_tokens=skip_special_tokens)
+        return self.tokenizer.batch_decode(
+            ids,
+            skip_special_tokens=skip_special_tokens,
+            clean_up_tokenization_spaces=False,
+        )
 
     def embed_ids(self, ids: IdsTensor, as_targets: bool = False) -> EmbeddingsTensor:
         if as_targets and not self.is_encoder_decoder:


### PR DESCRIPTION
## Description

Fixes #198 by forcing `clean_up_tokenization_spaces=False` at in `HuggingfaceModel.decode`, ensuring consistency between `input_texts` and `generated_texts` for decoder-only models.
