### PR TITLE
Step functions fixes, add `in_context_pvi`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,14 +159,15 @@ Use the `inseq.list_feature_attribution_methods` function to list all available 
 Step functions are used to extract custom scores from the model at each step of the attribution process with the `step_scores` argument in `model.attribute`. They can also be used as targets for attribution methods relying on model outputs (e.g. gradient-based methods) by passing them as the `attributed_fn` argument. The following step functions are currently supported:
 
 - `logits`: Logits of the target token.
-- `probability`: Probability of the target token.
+- `probability`: Probability of the target token. Can also be used for log-probability by passing `logprob=True`.
 - `entropy`: Entropy of the predictive distribution.
 - `crossentropy`: Cross-entropy loss between target token and predicted distribution.
 - `perplexity`: Perplexity of the target token.
-- `contrast_prob`: Probability of the target token when different contrastive inputs are provided to the model. Equivalent to `probability` when no contrastive inputs are provided.
+- `contrast_logits`/`contrast_prob`: Logits/probabilities of the target token when different contrastive inputs are provided to the model. Equivalent to `logits`/`probability` when no contrastive inputs are provided.
+- `contrast_logits_diff`/`contrast_prob_diff`: Difference in logits/probability between original and foil target tokens pair, can be used for contrastive evaluation as in [contrastive attribution](https://aclanthology.org/2022.emnlp-main.14/) (Yin and Neubig, 2022).
 - `pcxmi`: Point-wise Contextual Cross-Mutual Information (P-CXMI) for the target token given original and contrastive contexts [(Yin et al. 2021)](https://arxiv.org/abs/2109.07446).
 - `kl_divergence`: KL divergence of the predictive distribution given original and contrastive contexts. Can be restricted to most likely target token options using the `top_k` and `top_p` parameters.
-- `contrast_prob_diff`: Difference in probability between original and foil target tokens pair, can be used for contrastive evaluation as in [Contrastive Attribution](https://aclanthology.org/2022.emnlp-main.14/) (Yin and Neubig, 2022).
+- `in_context_pvi`: In-context Pointwise V-usable Information (PVI) to measure the amount of contextual information used in model predictions [(Lu et al. 2023)](https://arxiv.org/abs/2310.12300).
 - `mc_dropout_prob_avg`: Average probability of the target token across multiple samples using [MC Dropout](https://arxiv.org/abs/1506.02142) (Gal and Ghahramani, 2016).
 - `top_p_size`: The number of tokens with cumulative probability greater than `top_p` in the predictive distribution of the model.
 

--- a/docs/source/main_classes/step_functions.rst
+++ b/docs/source/main_classes/step_functions.rst
@@ -37,13 +37,19 @@ The following functions can be used out-of-the-box as attribution targets or ste
 
 .. autofunction:: perplexity_fn
 
+.. autofunction:: contrast_logit_fn
+
 .. autofunction:: contrast_prob_fn
+
+.. autofunction:: contrast_logit_diff_fn
+
+.. autofunction:: contrast_prob_diff_fn
 
 .. autofunction:: pcxmi_fn
 
 .. autofunction:: kl_divergence_fn
 
-.. autofunction:: contrast_prob_diff_fn
+.. autofunction:: in_context_pvi_fn
 
 .. autofunction:: mc_dropout_prob_avg_fn
 

--- a/docs/source/main_classes/step_functions.rst
+++ b/docs/source/main_classes/step_functions.rst
@@ -37,11 +37,11 @@ The following functions can be used out-of-the-box as attribution targets or ste
 
 .. autofunction:: perplexity_fn
 
-.. autofunction:: contrast_logit_fn
+.. autofunction:: contrast_logits_fn
 
 .. autofunction:: contrast_prob_fn
 
-.. autofunction:: contrast_logit_diff_fn
+.. autofunction:: contrast_logits_diff_fn
 
 .. autofunction:: contrast_prob_diff_fn
 

--- a/inseq/attr/step_functions.py
+++ b/inseq/attr/step_functions.py
@@ -222,7 +222,7 @@ def _get_contrast_output(
 
 
 @contrast_fn_docstring()
-def contrast_logit_fn(
+def contrast_logits_fn(
     args: StepFunctionArgs,
     contrast_sources: Optional[FeatureAttributionInput] = None,
     contrast_target_prefixes: Optional[FeatureAttributionInput] = None,
@@ -383,7 +383,7 @@ def contrast_prob_diff_fn(
 
 
 @contrast_fn_docstring()
-def contrast_logit_diff_fn(
+def contrast_logits_diff_fn(
     args: StepFunctionArgs,
     contrast_sources: Optional[FeatureAttributionInput] = None,
     contrast_target_prefixes: Optional[FeatureAttributionInput] = None,
@@ -394,7 +394,7 @@ def contrast_logit_diff_fn(
     `Yin and Neubig (2022) <https://aclanthology.org/2022.emnlp-main.14>`__
     """
     model_logits = logit_fn(args)
-    contrast_logits = contrast_logit_fn(
+    contrast_logits = contrast_logits_fn(
         args=args,
         contrast_sources=contrast_sources,
         contrast_target_prefixes=contrast_target_prefixes,
@@ -489,9 +489,9 @@ STEP_SCORES_MAP = {
     "entropy": entropy_fn,
     "crossentropy": crossentropy_fn,
     "perplexity": perplexity_fn,
-    "contrast_logit": contrast_logit_fn,
+    "contrast_logits": contrast_logits_fn,
     "contrast_prob": contrast_prob_fn,
-    "contrast_logit_diff": contrast_logit_diff_fn,
+    "contrast_logits_diff": contrast_logits_diff_fn,
     "contrast_prob_diff": contrast_prob_diff_fn,
     "pcxmi": pcxmi_fn,
     "kl_divergence": kl_divergence_fn,

--- a/inseq/utils/__init__.py
+++ b/inseq/utils/__init__.py
@@ -48,10 +48,10 @@ from .torch_utils import (
     aggregate_contiguous,
     check_device,
     euclidean_distance,
+    filter_logits,
     get_default_device,
     get_front_padding,
     get_sequences_from_batched_steps,
-    logits_kl_divergence,
     normalize,
     remap_from_filtered,
     top_p_logits_mask,
@@ -116,5 +116,5 @@ __all__ = [
     "get_adjusted_alignments",
     "get_aligned_idx",
     "top_p_logits_mask",
-    "logits_kl_divergence",
+    "filter_logits",
 ]

--- a/tests/utils/test_torch_utils.py
+++ b/tests/utils/test_torch_utils.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from inseq.utils.misc import pretty_tensor
+from inseq.utils.torch_utils import filter_logits
 
 
 @pytest.mark.parametrize(
@@ -46,3 +47,31 @@ def test_probits2prob():
     probs = torch.gather(probits, -1, target_ids.T)
     assert probs.shape == (1, 1)
     assert torch.eq(probs, torch.tensor([23456.0])).all()
+
+
+def test_filter_logits():
+    original_logits = torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0, 5.0],
+            [2.0, 3.0, 4.0, 5.0, 6.0],
+            [3.0, 4.0, 5.0, 6.0, 7.0],
+            [4.0, 5.0, 6.0, 7.0, 8.0],
+        ]
+    )
+    filtered_logits = filter_logits(original_logits, top_k=2)
+    topk2 = original_logits.clone().index_fill(1, torch.tensor([0, 1, 2]), float("-inf"))
+    assert torch.eq(filtered_logits, topk2).all()
+    filtered_logits = filter_logits(original_logits, top_p=0.9)
+    topp90 = original_logits.clone().index_fill(1, torch.tensor([0, 1]), float("-inf"))
+    assert torch.eq(filtered_logits, topp90).all()
+    contrast_logits = torch.tensor(
+        [
+            [15.0, 13.0, 11.0, 9.0, 7.0],
+            [13.0, 11.0, 9.0, 7.0, 5.0],
+            [11.0, 9.0, 7.0, 5.0, 3.0],
+            [9.0, 7.0, 5.0, 3.0, 1.0],
+        ]
+    )
+    filtered_logits, contrast_logits = filter_logits(original_logits, contrast_logits=contrast_logits, top_k=2)
+    top2merged = original_logits.clone().index_fill(1, torch.tensor([2, 3, 4]), float("-inf"))
+    assert torch.eq(filtered_logits, top2merged).all()


### PR DESCRIPTION
## Description

This PR:

- Fixes the top-k and top-p filtering for the `kl_divergence` step function with a more general utility function
- Adds pre-registered `contrast_logit_fn` and `contrast_logit_diff_fn`, equivalent to `contrast_prob_fn` and `contrast_prob_diff_fn` but using pre-softmax logits instead of probabilities.
- Add the `logprobs` boolean parameter to `probability_fn`, `contrast_prob_fn`, `contrast_prob_diff_fn` and `mc_dropout_prob_avg_fn` to allow for using `F.log_softmax` log-probabilities instead of `F.softmax` probabilities (default behavior)
- Add the `in_context_pvi` step function for calculating in-context pointwise V-usable information [(Lu et al. 2023)](https://arxiv.org/abs/2310.12300), using @boblus implementation from [boblus/in-context-pvi](https://github.com/boblus/in-context-pvi)