### PR TITLE
Remove contrast_target_prefixes from contrastive step functions

### DIFF
--- a/docs/source/examples/custom_attribute_target.rst
+++ b/docs/source/examples/custom_attribute_target.rst
@@ -40,7 +40,7 @@ with Contrastive Explanations" <https://arxiv.org/abs/2202.10419>`__ by Yin and 
 by complementing the output probabilities with the ones from their contrastive counterpart, and using the difference between the two as attribution
 target.
 
-We can define such attribution function using the standard template adopted by Inseq. The :class:`~inseq.attr.step_functions.StepFunctionArgs` class is used for convenience to encapsulate all default arguments passed to step functions, namely:
+We can define such attribution function using the standard template adopted by Inseq. The :class:`~inseq.attr.step_functions.StepFunctionDecoderOnlyArgs` and :class:`~inseq.attr.step_functions.StepFunctionEncoderDecoderArgs` classes are used for convenience to encapsulate all default arguments passed to step functions, namely:
 
 - :obj:`attribution_model`: the attribution model used to compute attributions.
 

--- a/docs/source/main_classes/step_functions.rst
+++ b/docs/source/main_classes/step_functions.rst
@@ -18,9 +18,9 @@ Step Functions
 Step Functions Default arguments
 -----------------------------------------------------------------------------------------------------------------------
 
-The default arguments passed to all step functions are collected in the :class:`StepFunctionArgs` class.
+The default arguments passed to all step functions are collected in the :class:`StepFunctionBaseArgs` class.
 
-.. autoclass:: StepFunctionArgs
+.. autoclass:: StepFunctionBaseArgs
 
 Pre-registered Step Functions
 -----------------------------------------------------------------------------------------------------------------------

--- a/examples/inseq_tutorial.ipynb
+++ b/examples/inseq_tutorial.ipynb
@@ -1116,21 +1116,23 @@
     "\n",
     "### Contrastive attribution with different context\n",
     "\n",
-    "While `contrast_targets` allows us to compute the *difference between two predictions given same context*, `contrast_sources` and `contrast_target_prefixes` can be instead used to compute the *difference for the same prediction given different contexts*. This is useful to analyze how the model behavior changes when presented with different inputs, and can be used to analyze the effect of different prefixes on the generation of the same target sequence.\n",
+    "While `contrast_targets` allows us to compute the *difference between two predictions given same context*, it can also be used alongsides `contrast_sources` to compute the *difference for the same prediction given different contexts*. This is useful to analyze how the model behavior changes when presented with different inputs, and can be used to analyze the effect of different prefixes on the generation of the same target sequence.\n",
     "\n",
     "In this example, we'll use a multilingual MT model to showcase the difference in probabilities given additional context:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/gsarti/.cache/pypoetry/virtualenvs/inseq-PzwjmCYf-py3.9/lib/python3.9/site-packages/transformers/generation/utils.py:1349: UserWarning: Using `max_length`'s default (200) to control the generation length. This behaviour is deprecated and will be removed from the config in v5 of Transformers -- we recommend using `max_new_tokens` to control the maximum length of the generation.\n",
+      "/home/gsarti/.cache/pypoetry/virtualenvs/inseq-PzwjmCYf-py3.9/lib/python3.9/site-packages/transformers/generation/utils.py:1270: UserWarning: You have modified the pretrained model configuration to control generation. This is a deprecated strategy to control generation and will be removed soon, in a future version. Please use a generation configuration file (see https://huggingface.co/docs/transformers/main_classes/text_generation )\n",
+      "  warnings.warn(\n",
+      "/home/gsarti/.cache/pypoetry/virtualenvs/inseq-PzwjmCYf-py3.9/lib/python3.9/site-packages/transformers/generation/utils.py:1369: UserWarning: Using `max_length`'s default (200) to control the generation length. This behaviour is deprecated and will be removed from the config in v5 of Transformers -- we recommend using `max_new_tokens` to control the maximum length of the generation.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1138,7 +1140,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Generation without context: ['Sapete già quando tornerete?']\n",
+      "Generation without context: ['Sapete già quando tornerete?']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Provided alignments do not cover all 8 tokens from the original sequence.\n",
+      "Filling missing position with right-aligned 1:1 position alignments.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Generation with context: [\"Grazie per l'aiuto, amico, mi hai davvero salvato la vita. Sapete già quando tornerete?\"]\n"
      ]
     },
@@ -1146,7 +1162,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Attributing with dummy...: 100%|██████████| 9/9 [00:00<00:00, 15.78it/s]\n"
+      "Attributing with dummy...: 100%|██████████| 9/9 [00:00<00:00, 15.59it/s]\n"
      ]
     },
     {
@@ -1154,11 +1170,11 @@
       "text/html": [
        "<br/><b>0th instance:</b><br/>\n",
        "<html>\n",
-       "<div id=\"cgchqjjfgyqpesejzqor_viz_container\">\n",
-       "    <div id=\"cgchqjjfgyqpesejzqor_content\" style=\"padding:15px;border-style:solid;margin:5px;\">\n",
-       "        <div id = \"cgchqjjfgyqpesejzqor_saliency_plot_container\" class=\"cgchqjjfgyqpesejzqor_viz_container\" style=\"display:block\">\n",
+       "<div id=\"jprrjeoajqpnsrahjfkf_viz_container\">\n",
+       "    <div id=\"jprrjeoajqpnsrahjfkf_content\" style=\"padding:15px;border-style:solid;margin:5px;\">\n",
+       "        <div id = \"jprrjeoajqpnsrahjfkf_saliency_plot_container\" class=\"jprrjeoajqpnsrahjfkf_viz_container\" style=\"display:block\">\n",
        "            \n",
-       "<div id=\"yiccwpusnzjovqwpsbfh_saliency_plot\" class=\"yiccwpusnzjovqwpsbfh_viz_content\">\n",
+       "<div id=\"evpxmqhjjhszbiryjbnq_saliency_plot\" class=\"evpxmqhjjhszbiryjbnq_viz_content\">\n",
        "    <div style=\"margin:5px;font-family:sans-serif;font-weight:bold;\">\n",
        "        <span style=\"font-size: 20px;\">Target Saliency Heatmap</span>\n",
        "        <br>\n",
@@ -1168,7 +1184,7 @@
        "<table border=\"1\" cellpadding=\"5\" cellspacing=\"5\"\n",
        "    style=\"overflow-x:scroll;display:block;\">\n",
        "    <tr><th></th>\n",
-       "<th>it_IT</th><th>▁Sai</th><th>▁già</th><th>▁quando</th><th>▁torne</th><th>rai</th><th>?</th><th>&lt;/s&gt;</th></tr><tr style=\"outline: thin solid\"><th><b>pcxmi</b></th><th><b>-8.093</b></th><th><b>2.096</b></th><th>-0.214</th><th>0.007</th><th>0.158</th><th>0.044</th><th>-0.068</th><th>-0.02</th><tr style=\"outline: thin solid\"><th><b>probability</b></th><th>0.0</th><th>0.02</th><th><b>0.834</b></th><th><b>0.927</b></th><th>0.475</th><th><b>0.93</b></th><th><b>0.645</b></th><th><b>0.897</b></th></table>\n",
+       "<th>. → it_IT</th><th>▁Sai</th><th>▁già</th><th>▁quando</th><th>▁torne</th><th>rai</th><th>?</th><th>&lt;/s&gt;</th></tr><tr style=\"outline: thin solid\"><th><b>pcxmi</b></th><th><b>10.656</b></th><th><b>2.602</b></th><th>-0.259</th><th>-0.008</th><th>-0.046</th><th>0.036</th><th>0.072</th><th>-0.013</th><tr style=\"outline: thin solid\"><th><b>probability</b></th><th>0.0</th><th>0.02</th><th><b>0.834</b></th><th><b>0.927</b></th><th>0.475</th><th><b>0.93</b></th><th><b>0.645</b></th><th><b>0.897</b></th></table>\n",
        "</div>\n",
        "\n",
        "        </div>\n",
@@ -1205,7 +1221,7 @@
     "    source_without_context,\n",
     "    \"Sai già quando tornerai?\",\n",
     "    contrast_sources=source_with_context,\n",
-    "    contrast_target_prefixes=\"Grazie per il tuo aiuto, mi hai davvero salvato la vita.\",\n",
+    "    contrast_targets=\"Grazie per il tuo aiuto, mi hai davvero salvato la vita. Sai già quando tornerai?\",\n",
     "    attribute_target=True,\n",
     "    # We also visualize the score used as target using the same function as step score\n",
     "    step_scores=[\"pcxmi\", \"probability\"]\n",
@@ -1219,7 +1235,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The high value of P-CXMI step score for `Sai` here points to the fact that given the full context, the model is twice as likely to predict `Sai` rather than other options.\n",
+    "By default tokens in the contrastive target are right-aligned to match the end of the original one. In this case, the very high value of P-CXMI step score for the language token `it_IT` is not very meaningful, as it would not be produced naturally by the model. However, `Sai` also has a high score here, pointing to the fact that given the full context, the model is more than twice as likely to predict `Sai` rather than other options. This is reasonable, as the context provides the model with lexical cues like `tuo`, `hai` pointing to an informal register (i.e. `Sai` vs. the original formal `Sa`). Note that the informal `tornerai` is not picked up by P-CXMI as `Sai` is an intra-sentence cue that is present both in the contextless and the contextual cases.\n",
     "\n",
     "### Providing custom alignments for contrastive targets\n",
     "\n",

--- a/inseq/attr/__init__.py
+++ b/inseq/attr/__init__.py
@@ -2,6 +2,7 @@ from .feat import FeatureAttribution, extract_args, list_feature_attribution_met
 from .step_functions import (
     STEP_SCORES_MAP,
     StepFunctionArgs,
+    StepFunctionEncoderDecoderArgs,
     list_step_functions,
     register_step_function,
 )
@@ -14,4 +15,5 @@ __all__ = [
     "STEP_SCORES_MAP",
     "extract_args",
     "StepFunctionArgs",
+    "StepFunctionEncoderDecoderArgs",
 ]

--- a/inseq/models/attribution_model.py
+++ b/inseq/models/attribution_model.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple, TypeVar
 
 import torch
 
-from ..attr import STEP_SCORES_MAP, StepFunctionArgs
+from ..attr import STEP_SCORES_MAP, StepFunctionArgs, StepFunctionEncoderDecoderArgs
 from ..attr.feat import FeatureAttribution, extract_args, join_token_ids
 from ..data import (
     BatchEncoding,
@@ -145,7 +145,7 @@ class InputFormatter:
 
     @staticmethod
     def get_step_function_reserved_args() -> List[str]:
-        return [f.name for f in StepFunctionArgs.__dataclass_fields__.values()]
+        return [f.name for f in StepFunctionEncoderDecoderArgs.__dataclass_fields__.values()]
 
     @staticmethod
     def format_contrast_targets_alignments(

--- a/tests/attr/feat/test_feature_attribution.py
+++ b/tests/attr/feat/test_feature_attribution.py
@@ -101,37 +101,6 @@ def test_contrastive_attribution_seq2seq_alignments(saliency_mt_model_larger: Hu
         atol=8e-2,
     )
 
-    # Check that providing only non-matching ids also works
-    out_non_matching_ids = saliency_mt_model_larger.attribute(
-        aligned["src"],
-        aligned["orig_tgt"],
-        attributed_fn="contrast_prob_diff",
-        step_scores=["contrast_prob_diff"],
-        contrast_targets=aligned["contrast_tgt"],
-        contrast_targets_alignments=[(3, 4), (4, 5), (5, 7), (6, 9)],
-        show_progress=False,
-    )
-    assert out[0].target == out_non_matching_ids[0].target
-    assert torch.allclose(
-        out[0].source_attributions,
-        out_non_matching_ids[0].source_attributions,
-        atol=8e-2,
-    )
-
-
-def test_contrastive_attribution_gpt_alignments(saliency_gpt_model_larger: HuggingfaceDecoderOnlyModel):
-    out = saliency_gpt_model_larger.attribute(
-        "UN peacekeepers",
-        "UN peacekeepers were deployed in the region.",
-        attributed_fn="contrast_prob_diff",
-        contrast_targets="UN peacekeepers were sent to the war-torn region.",
-        contrast_targets_alignments=[(7, 10), (8, 11)],
-        step_scores=["contrast_prob_diff"],
-        show_progress=False,
-    )
-    contrast_targets = ["UN", "Ġpeace", "keepers", "Ġwere", "Ġsent → Ġdeployed", "Ġto → Ġin", "Ġthe", "Ġregion", "."]
-    assert [t.token for t in out[0].target] == contrast_targets
-
 
 def test_mcd_weighted_attribution_seq2seq(saliency_mt_model):
     """Runs a MCD-weighted feature attribution taking advantage of

--- a/tests/attr/feat/test_step_functions.py
+++ b/tests/attr/feat/test_step_functions.py
@@ -20,7 +20,7 @@ def test_contrast_prob_consistency_decoder(saliency_gpt2: DecoderOnlyAttribution
         " the manager opened her own restaurant.",
         attribute_target=True,
         step_scores=["contrast_prob"],
-        contrast_target_prefixes="After returning to her hometown,",
+        contrast_targets="After returning to her hometown, the manager opened her own restaurant.",
     )
     contrast_prob = out_contrast.sequence_attributions[0].step_scores["contrast_prob"]
     out_regular = saliency_gpt2.attribute(
@@ -35,12 +35,12 @@ def test_contrast_prob_consistency_decoder(saliency_gpt2: DecoderOnlyAttribution
 
 def test_contrast_prob_consistency_enc_dec(saliency_mt_model: EncoderDecoderAttributionModel):
     out_contrast = saliency_mt_model.attribute(
-        " started working as a cook in London.",
-        " ha iniziato a lavorare come cuoca a Londra.",
+        "she started working as a cook in London.",
+        "ha iniziato a lavorare come cuoca a Londra.",
         attribute_target=True,
         step_scores=["contrast_prob"],
         contrast_sources="After finishing her studies, she started working as a cook in London.",
-        contrast_target_prefixes="Dopo aver terminato gli studi,",
+        contrast_targets="Dopo aver terminato gli studi, ha iniziato a lavorare come cuoca a Londra.",
     )
     contrast_prob = out_contrast.sequence_attributions[0].step_scores["contrast_prob"]
     out_regular = saliency_mt_model.attribute(
@@ -51,88 +51,3 @@ def test_contrast_prob_consistency_enc_dec(saliency_mt_model: EncoderDecoderAttr
     )
     regular_prob = out_regular.sequence_attributions[0].step_scores["probability"]
     assert all(c == r for c, r in zip(contrast_prob, regular_prob[-len(contrast_prob) :]))
-
-
-def test_contrast_prob_diff_contrast_targets_auto_align_seq2seq(saliency_mt_model: EncoderDecoderAttributionModel):
-    out = saliency_mt_model.attribute(
-        (
-            " UN peacekeepers, whom arrived in Haiti after the 2010 earthquake, are being blamed for the spread of the"
-            " disease which started near the troop's encampment."
-        ),
-        (
-            "I soldati della pace dell'ONU, che sono arrivati ad Haiti dopo il terremoto del 2010, sono stati"
-            " incolpati per la diffusione della malattia che è iniziata vicino al campo delle truppe."
-        ),
-        attributed_fn="contrast_prob_diff",
-        step_scores=["contrast_prob_diff"],
-        contrast_targets=(
-            "Le forze di pace delle Nazioni Unite, arrivate ad Haiti dopo il terremoto del 2010, sono state accusate"
-            " di aver diffuso la malattia iniziata nei pressi dell'accampamento delle truppe."
-        ),
-        contrast_targets_alignments="auto",
-    )
-    contrast_targets = [
-        "▁Le → ▁I",
-        "▁forze → ▁soldati",
-        "▁di → ▁della",
-        "▁pace",
-        "▁delle → ▁dell",
-        "▁delle → '",
-        "▁Nazioni → ONU",
-        ",",
-        "▁arriva → ▁che",
-        "te → ▁sono",
-        "▁arriva → ▁arrivati",
-        "▁ad",
-        "▁Haiti",
-        "▁dopo",
-        "▁il",
-        "▁terremoto",
-        "▁del",
-        "▁2010,",
-        "▁sono",
-        "▁state → ▁stati",
-        "▁accusa → ▁in",
-        "te → col",
-        "▁accusa → pati",
-        "▁di → ▁per",
-        "▁aver → ▁la",
-        "▁diffuso → ▁diffusione",
-        "▁la → ▁della",
-        "▁malattia",
-        "▁iniziata → ▁che",
-        "▁dell → ▁è",
-        "▁iniziata",
-        "▁pressi → ▁vicino",
-        "▁nei → ▁al",
-        "acca → ▁campo",
-        "▁delle",
-        "▁truppe",
-        ".",
-        "</s>",
-    ]
-    assert [t.token for t in out[0].target] == contrast_targets
-
-
-def test_contrast_prob_diff_contrast_targets_auto_align_gpt(saliency_gpt2: DecoderOnlyAttributionModel):
-    out = saliency_gpt2.attribute(
-        "",
-        "UN peacekeepers were deployed in the region.",
-        attributed_fn="contrast_prob_diff",
-        contrast_targets="<|endoftext|> UN peacekeepers were sent to the war-torn region.",
-        contrast_targets_alignments="auto",
-        step_scores=["contrast_prob_diff"],
-    )
-    contrast_targets = [
-        "<|endoftext|>",
-        "ĠUN",
-        "Ġpeace",
-        "keepers",
-        "Ġwere",
-        "Ġsent → Ġdeployed",
-        "Ġto → Ġin",
-        "Ġthe",
-        "Ġregion",
-        ".",
-    ]
-    assert [t.token for t in out[0].target] == contrast_targets


### PR DESCRIPTION
## Description

This PR removes the `contrast_target_prefixes` argument from all contrastive functions and implements default right-side alignment of contrastive sequences. This allows a more intuitive usage of contrastive step functions that 1) doesn't require splitting manually the contrastive target prefix and 2) works out of the box for decoder-only LMs:

Example before:

```python
mt_model.attribute(
    "she started working as a cook in London.",
    "ha iniziato a lavorare come cuoca a Londra.",
    contrast_sources="After finishing her studies, she started working as a cook in London.",
    contrast_target_prefixes="Dopo aver terminato gli studi, ",
)
```

After:

```python
mt_model.attribute(
    "she started working as a cook in London.",
    "ha iniziato a lavorare come cuoca a Londra.",
    contrast_sources="After finishing her studies, she started working as a cook in London.",
	contrast_targets="Dopo aver terminato gli studi, ha iniziato a lavorare come cuoca a Londra.",
)
```
