### PR TITLE
Fix command for installing pre-commit hooks.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ To install dependencies and prepare [`pre-commit`](https://pre-commit.com/) hook
 
 ```bash
 make install
-make pre-commit-install
+make install-dev
 ```
 
 To activate your `virtualenv` run `poetry shell`.


### PR DESCRIPTION
`make pre-commit-install` does not exist any longer, `make install-dev` seems to be the right choice now.

## Type of Change

- 📚 Examples / docs / tutorials / dependencies update

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/inseq-team/inseq/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/inseq-team/inseq/blob/master/CONTRIBUTING.md) guide.
- [ ] I've successfully run the style checks using `make fix-style`.
- [ ] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
