### PR TITLE
Fix casting step outputs to device

### DIFF
--- a/inseq/attr/feat/feature_attribution.py
+++ b/inseq/attr/feat/feature_attribution.py
@@ -590,11 +590,11 @@ class FeatureAttribution(Registry):
                 batch=batch,
             )
             step_fn_extra_args = get_step_scores_args([score], step_scores_args)
-            step_output.step_scores[score] = get_step_scores(score, step_fn_args, step_fn_extra_args)
+            step_output.step_scores[score] = get_step_scores(score, step_fn_args, step_fn_extra_args).to("cpu")
         # Reinsert finished sentences
         if target_attention_mask is not None and is_filtered:
             step_output.remap_from_filtered(target_attention_mask, orig_batch)
-        step_output = step_output.detach()
+        step_output = step_output.detach().to("cpu")
         return step_output
 
     def get_attribution_args(self, **kwargs) -> tuple[dict[str, Any], dict[str, Any]]:


### PR DESCRIPTION
## Description

Ensures the outcome of the `attribute_step` method is always on `cpu` to minimize GPU memory allocation, while also preventing device issues raised in #251 
