### PR TITLE
Fix URL to arXiv

### DIFF
--- a/docs/source/main_classes/cli.rst
+++ b/docs/source/main_classes/cli.rst
@@ -23,7 +23,7 @@ Three commands are supported:
 
 - ``inseq attribute-dataset``: Extends ``attribute`` to full dataset using Hugging Face ``datasets.load_dataset`` API.
 
-- ``inseq attribute-context``: Detects and attribute context dependence for generation tasks using the approach of `Sarti et al. (2023) <https://arxiv.org/abs/2310.0118>`__.
+- ``inseq attribute-context``: Detects and attribute context dependence for generation tasks using the approach of `Sarti et al. (2023) <https://arxiv.org/abs/2310.01188>`__.
 
 ``attribute``
 -----------------------------------------------------------------------------------------------------------------------
@@ -47,6 +47,6 @@ The ``attribute-dataset`` command extends the ``attribute`` command to full data
 -----------------------------------------------------------------------------------------------------------------------
 
 The ``attribute-context`` command detects and attributes context dependence for generation tasks using the approach of
-`Sarti et al. (2023) <https://arxiv.org/abs/2310.0118>`__. The command takes the following arguments:
+`Sarti et al. (2023) <https://arxiv.org/abs/2310.01188>`__. The command takes the following arguments:
 
 .. autoclass:: inseq.commands.attribute_context.attribute_context_args.AttributeContextArgs


### PR DESCRIPTION
## Description

The URL was missing a digit, resulting in a link to an unrelated paper.

## Related Issue

## Type of Change
- 📚 Examples / docs / tutorials / dependencies update
- 🔧 Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/inseq-team/inseq/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/inseq-team/inseq/blob/master/CONTRIBUTING.md) guide.
- [ ] I've successfully run the style checks using `make fix-style`.
- [ ] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
