### PR TITLE
Update lime.py

### DIFF
--- a/inseq/attr/feat/ops/lime.py
+++ b/inseq/attr/feat/ops/lime.py
@@ -259,7 +259,7 @@ class Lime(LimeBase):
             )
 
             def detach_to_list(t):
-                return t.detach().cpu().numpy().tolist() if type(t) == torch.Tensor else t
+                return t.detach().float().cpu().numpy().tolist() if type(t) == torch.Tensor else t
 
             # Additionally remove special_token_ids
             mask_special_token_ids = torch.Tensor(


### PR DESCRIPTION
Convert tensor's dtype to "float" before moving to CPU, which avoids errors when using "bf16"

## Description

add .float() before .cpu() to support half precision data type

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/inseq-team/inseq/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/inseq-team/inseq/blob/master/CONTRIBUTING.md) guide.
- [ ] I've successfully run the style checks using `make fix-style`.
- [ ] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
