### PR TITLE
Add support for `device_map` use

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,9 +25,9 @@ copyright = "2024 , The Inseq Team, Licensed under the Apache License, Version 2
 author = "The Inseq Team"
 
 # The short X.Y version
-version = "0.6"
+version = "0.7"
 # The full version, including alpha/beta/rc tags
-release = "0.6.0"
+release = "0.7.0.dev0"
 
 
 # Prefix link to point to master, comment this during version release and uncomment below line

--- a/inseq/models/attribution_model.py
+++ b/inseq/models/attribution_model.py
@@ -22,7 +22,6 @@ from ..utils import (
     format_input_texts,
     get_adjusted_alignments,
     get_default_device,
-    is_accelerate_available,
     isnotebook,
     pretty_tensor,
 )
@@ -236,14 +235,7 @@ class AttributionModel(ABC, torch.nn.Module):
         check_device(new_device)
         self._device = new_device
         if self.model:
-            if self.device_map is None:
-                self.model.to(self._device)
-            elif is_accelerate_available():
-                from accelerate import dispatch_model
-
-                self.model = dispatch_model(self.model, device_map=self.device_map)
-            else:
-                raise ImportError("Accelerate is not available, but device_map is set.")
+            self.model.to(self._device)
 
     def setup(self, device: Optional[str] = None, attribution_method: Optional[str] = None, **kwargs) -> None:
         """Move the model to device and in eval mode."""

--- a/inseq/models/huggingface_model.py
+++ b/inseq/models/huggingface_model.py
@@ -165,16 +165,19 @@ class HuggingfaceModel(AttributionModel):
         is_loaded_in_8bit = getattr(self.model, "is_loaded_in_8bit", False)
         is_loaded_in_4bit = getattr(self.model, "is_loaded_in_4bit", False)
         is_quantized = is_loaded_in_8bit or is_loaded_in_4bit
+        has_device_map = self.device_map is not None
 
         # Enable compatibility with 8bit models
         if self.model:
-            if not is_quantized:
-                self.model.to(self._device)
-            else:
+            if is_quantized:
                 mode = "8bit" if is_loaded_in_8bit else "4bit"
                 logger.warning(
                     f"The model is loaded in {mode} mode. The device cannot be changed after loading the model."
                 )
+            elif has_device_map:
+                logger.warning("The model is loaded with a device map. The device cannot be changed after loading.")
+            else:
+                self.model.to(self._device)
 
     @abstractmethod
     def configure_embeddings_scale(self) -> None:

--- a/inseq/models/huggingface_model.py
+++ b/inseq/models/huggingface_model.py
@@ -127,6 +127,9 @@ class HuggingfaceModel(AttributionModel):
         self.embed_scale = 1.0
         self.encoder_int_embeds = None
         self.decoder_int_embeds = None
+        self.device_map = None
+        if hasattr(self.model, "hf_device_map") and self.model.hf_device_map is not None:
+            self.device_map = self.model.hf_device_map
         self.is_encoder_decoder = self.model.config.is_encoder_decoder
         self.configure_embeddings_scale()
         self.setup(device, attribution_method, **kwargs)

--- a/inseq/utils/__init__.py
+++ b/inseq/utils/__init__.py
@@ -10,6 +10,7 @@ from .errors import (
 )
 from .hooks import StackFrame, get_post_variable_assignment_hook
 from .import_utils import (
+    is_accelerate_available,
     is_captum_available,
     is_datasets_available,
     is_ipywidgets_available,
@@ -130,4 +131,5 @@ __all__ = [
     "validate_indices",
     "pad_with_nan",
     "recursive_get_submodule",
+    "is_accelerate_available",
 ]

--- a/inseq/utils/import_utils.py
+++ b/inseq/utils/import_utils.py
@@ -8,6 +8,7 @@ _datasets_available = find_spec("datasets") is not None
 _captum_available = find_spec("captum") is not None
 _joblib_available = find_spec("joblib") is not None
 _nltk_available = find_spec("nltk") is not None
+_accelerate_available = find_spec("accelerate") is not None
 
 
 def is_ipywidgets_available():
@@ -40,3 +41,7 @@ def is_joblib_available():
 
 def is_nltk_available():
     return _nltk_available
+
+
+def is_accelerate_available():
+    return _accelerate_available

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "inseq"
-version = "0.6.0"
+version = "0.7.0.dev0"
 description = "Interpretability for Sequence Generation Models 🔍"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Description

This PR adds support for using a custom `device_map` in the loaded HF model, avoiding to cast it to a device in `AttributionModel.setup()` if the device map is specified, and dispatching it using the `accelerate.dispatch_model` method instead.
