### PR TITLE
Add possibility to skip special tokens during attribution

### DIFF
--- a/inseq/attr/step_functions.py
+++ b/inseq/attr/step_functions.py
@@ -132,6 +132,7 @@ def contrast_logits_fn(
     contrast_targets: Optional[FeatureAttributionInput] = None,
     contrast_targets_alignments: Optional[list[list[tuple[int, int]]]] = None,
     contrast_force_inputs: bool = False,
+    skip_special_tokens: bool = False,
 ):
     """Returns the logit of a generation target given contrastive context or target prediction alternative.
     If only ``contrast_targets`` are specified, the logit of the contrastive prediction is computed given same
@@ -144,6 +145,7 @@ def contrast_logits_fn(
         contrast_targets=contrast_targets,
         contrast_targets_alignments=contrast_targets_alignments,
         contrast_force_inputs=contrast_force_inputs,
+        skip_special_tokens=skip_special_tokens,
     )
     return logit_fn(c_args)
 
@@ -156,6 +158,7 @@ def contrast_prob_fn(
     contrast_targets_alignments: Optional[list[list[tuple[int, int]]]] = None,
     logprob: bool = False,
     contrast_force_inputs: bool = False,
+    skip_special_tokens: bool = False,
 ):
     """Returns the probability of a generation target given contrastive context or target prediction alternative.
     If only ``contrast_targets`` are specified, the probability of the contrastive prediction is computed given same
@@ -168,6 +171,7 @@ def contrast_prob_fn(
         contrast_targets=contrast_targets,
         contrast_targets_alignments=contrast_targets_alignments,
         contrast_force_inputs=contrast_force_inputs,
+        skip_special_tokens=skip_special_tokens,
     )
     return probability_fn(c_args, logprob=logprob)
 
@@ -179,6 +183,7 @@ def pcxmi_fn(
     contrast_targets: Optional[FeatureAttributionInput] = None,
     contrast_targets_alignments: Optional[list[list[tuple[int, int]]]] = None,
     contrast_force_inputs: bool = False,
+    skip_special_tokens: bool = False,
 ) -> SingleScorePerStepTensor:
     """Compute the pointwise conditional cross-mutual information (P-CXMI) of target ids given original and contrastive
     input options. The P-CXMI is defined as the negative log-ratio between the conditional probability of the target
@@ -192,6 +197,7 @@ def pcxmi_fn(
         contrast_targets=contrast_targets,
         contrast_targets_alignments=contrast_targets_alignments,
         contrast_force_inputs=contrast_force_inputs,
+        skip_special_tokens=skip_special_tokens,
     ).to(original_probs.device)
     return -torch.log2(torch.div(original_probs, contrast_probs))
 
@@ -206,6 +212,7 @@ def kl_divergence_fn(
     top_p: float = 1.0,
     min_tokens_to_keep: int = 1,
     contrast_force_inputs: bool = False,
+    skip_special_tokens: bool = False,
 ) -> SingleScorePerStepTensor:
     """Compute the pointwise Kullback-Leibler divergence of target ids given original and contrastive input options.
     The KL divergence is the expectation of the log difference between the probabilities of regular (P) and contrastive
@@ -233,6 +240,7 @@ def kl_divergence_fn(
         contrast_targets_alignments=contrast_targets_alignments,
         return_contrastive_target_ids=False,
         return_contrastive_batch=True,
+        skip_special_tokens=skip_special_tokens,
     )
     c_forward_output = args.attribution_model.get_forward_output(
         contrast_inputs.batch, use_embeddings=args.attribution_model.is_encoder_decoder
@@ -263,6 +271,7 @@ def contrast_prob_diff_fn(
     contrast_targets_alignments: Optional[list[list[tuple[int, int]]]] = None,
     logprob: bool = False,
     contrast_force_inputs: bool = False,
+    skip_special_tokens: bool = False,
 ):
     """Returns the difference between next step probability for a candidate generation target vs. a contrastive
     alternative. Can be used as attribution target to answer the question: "Which features were salient in the
@@ -279,6 +288,7 @@ def contrast_prob_diff_fn(
         contrast_targets_alignments=contrast_targets_alignments,
         logprob=logprob,
         contrast_force_inputs=contrast_force_inputs,
+        skip_special_tokens=skip_special_tokens,
     ).to(model_probs.device)
     return model_probs - contrast_probs
 
@@ -290,6 +300,7 @@ def contrast_logits_diff_fn(
     contrast_targets: Optional[FeatureAttributionInput] = None,
     contrast_targets_alignments: Optional[list[list[tuple[int, int]]]] = None,
     contrast_force_inputs: bool = False,
+    skip_special_tokens: bool = False,
 ):
     """Equivalent to ``contrast_prob_diff_fn`` but for logits. The original target function used in
     `Yin and Neubig (2022) <https://aclanthology.org/2022.emnlp-main.14>`__
@@ -301,6 +312,7 @@ def contrast_logits_diff_fn(
         contrast_targets=contrast_targets,
         contrast_targets_alignments=contrast_targets_alignments,
         contrast_force_inputs=contrast_force_inputs,
+        skip_special_tokens=skip_special_tokens,
     ).to(model_logits.device)
     return model_logits - contrast_logits
 
@@ -312,6 +324,7 @@ def in_context_pvi_fn(
     contrast_targets: Optional[FeatureAttributionInput] = None,
     contrast_targets_alignments: Optional[list[list[tuple[int, int]]]] = None,
     contrast_force_inputs: bool = False,
+    skip_special_tokens: bool = False,
 ):
     """Returns the in-context pointwise V-usable information as defined by `Lu et al. (2023)
     <https://arxiv.org/abs/2310.12300>`__. In-context PVI is a variant of P-CXMI that captures the amount of usable
@@ -330,6 +343,7 @@ def in_context_pvi_fn(
         contrast_targets_alignments=contrast_targets_alignments,
         logprob=True,
         contrast_force_inputs=contrast_force_inputs,
+        skip_special_tokens=skip_special_tokens,
     ).to(orig_logprob.device)
     return -orig_logprob + contrast_logprob
 

--- a/inseq/data/attribution.py
+++ b/inseq/data/attribution.py
@@ -47,6 +47,7 @@ def get_batch_from_inputs(
     inputs: FeatureAttributionInput,
     include_eos_baseline: bool = False,
     as_targets: bool = False,
+    skip_special_tokens: bool = False,
 ) -> Batch:
     if isinstance(inputs, Batch):
         batch = inputs
@@ -57,6 +58,7 @@ def get_batch_from_inputs(
                 as_targets=as_targets,
                 return_baseline=True,
                 include_eos_baseline=include_eos_baseline,
+                add_special_tokens=not skip_special_tokens,
             )
         elif isinstance(inputs, BatchEncoding):
             encodings = inputs
@@ -66,8 +68,12 @@ def get_batch_from_inputs(
                 "Inputs must be either a string, a list of strings, a BatchEncoding or a Batch."
             )
         embeddings = BatchEmbedding(
-            input_embeds=attribution_model.embed(encodings.input_ids, as_targets=as_targets),
-            baseline_embeds=attribution_model.embed(encodings.baseline_ids, as_targets=as_targets),
+            input_embeds=attribution_model.embed(
+                encodings.input_ids, as_targets=as_targets, add_special_tokens=not skip_special_tokens
+            ),
+            baseline_embeds=attribution_model.embed(
+                encodings.baseline_ids, as_targets=as_targets, add_special_tokens=not skip_special_tokens
+            ),
         )
         batch = Batch(encodings, embeddings)
     return batch

--- a/inseq/models/decoder_only.py
+++ b/inseq/models/decoder_only.py
@@ -39,12 +39,14 @@ class DecoderOnlyInputFormatter(InputFormatter):
         attribution_model: "DecoderOnlyAttributionModel",
         inputs: FeatureAttributionInput,
         include_eos_baseline: bool = False,
+        skip_special_tokens: bool = False,
     ) -> DecoderOnlyBatch:
         batch = get_batch_from_inputs(
             attribution_model,
             inputs=inputs,
             include_eos_baseline=include_eos_baseline,
             as_targets=False,
+            skip_special_tokens=skip_special_tokens,
         )
         return DecoderOnlyBatch.from_batch(batch)
 

--- a/inseq/models/encoder_decoder.py
+++ b/inseq/models/encoder_decoder.py
@@ -38,6 +38,7 @@ class EncoderDecoderInputFormatter(InputFormatter):
         attribution_model: "EncoderDecoderAttributionModel",
         inputs: tuple[FeatureAttributionInput, FeatureAttributionInput],
         include_eos_baseline: bool = False,
+        skip_special_tokens: bool = False,
     ) -> EncoderDecoderBatch:
         r"""Prepares sources and target to produce an :class:`~inseq.data.EncoderDecoderBatch`.
         There are two stages of preparation:
@@ -67,12 +68,14 @@ class EncoderDecoderInputFormatter(InputFormatter):
             inputs=sources,
             include_eos_baseline=include_eos_baseline,
             as_targets=False,
+            skip_special_tokens=skip_special_tokens,
         )
         target_batch = get_batch_from_inputs(
             attribution_model,
             inputs=targets,
             include_eos_baseline=include_eos_baseline,
             as_targets=True,
+            skip_special_tokens=skip_special_tokens,
         )
         return EncoderDecoderBatch(source_batch, target_batch)
 

--- a/inseq/models/huggingface_model.py
+++ b/inseq/models/huggingface_model.py
@@ -228,7 +228,7 @@ class HuggingfaceModel(AttributionModel):
         if isinstance(inputs, str) or (
             isinstance(inputs, list) and len(inputs) > 0 and all(isinstance(x, str) for x in inputs)
         ):
-            inputs = self.encode(inputs)
+            inputs = self.encode(inputs, add_special_tokens=not skip_special_tokens)
         inputs = inputs.to(self.device)
         generation_out = self.model.generate(
             inputs=inputs.input_ids,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -199,7 +199,7 @@ pbr==6.0.0
     # via stevedore
 pexpect==4.9.0
     # via ipython
-pillow==10.2.0
+pillow==10.3.0
     # via matplotlib
 platformdirs==4.2.0
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -101,7 +101,7 @@ huggingface-hub==0.20.3
     #   transformers
 identify==2.5.34
     # via pre-commit
-idna==3.6
+idna==3.7
     # via
     #   requests
     #   yarl

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ packaging==23.2
     #   huggingface-hub
     #   matplotlib
     #   transformers
-pillow==10.2.0
+pillow==10.3.0
     # via matplotlib
 protobuf==4.25.2
     # via transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ huggingface-hub==0.20.3
     # via
     #   tokenizers
     #   transformers
-idna==3.6
+idna==3.7
     # via requests
 jaxtyping==0.2.25
 jinja2==3.1.3


### PR DESCRIPTION
## Description

This PR addresses the possibility of skipping special tokens during attribution using the `skip_special_tokens=True` argument.

Example usage (regular attribution):

```python
import inseq

model = inseq.load_model("mymusise/CPM-Generate-distill", "integrated_gradients")

out = model.attribute(
    input_texts=["她们是飞行员还是制片人", "她们是飞行员还是制片人"],
    generated_texts=["她们是飞行员还是制片人？", "她们是飞行员还是制片人吗？"],
    step_scores=["probability"],
    skip_special_tokens=True,
)

out.show()
```

Example usage (contrastive attribution):

```python
import inseq

model = inseq.load_model("mymusise/CPM-Generate-distill", "saliency")

out = model.attribute(
    input_texts="她们是飞行员还是制片人",
    generated_texts="她们是飞行员还是制片人？",
    skip_special_tokens=True, # New argument to skip special tokens
    contrast_targets="她们是飞行员还是制片人吗",
    attributed_fn="contrast_prob_diff",
    step_scores=["probability", "contrast_prob_diff"],
)

out.show()
```