### PR TITLE
Fix LLaMA 3.2, add `clean_special_chars`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install:
 .PHONY: install-dev
 install-dev:
 	make uv-activate && uv pip install -r requirements-dev.txt && pre-commit install && pre-commit autoupdate
-	
+
 
 .PHONY: install-ci
 install-ci:
@@ -82,7 +82,7 @@ fix-style:
 
 .PHONY: check-safety
 check-safety:
-	$(PYTHON) -m safety check --full-report -i 70612 -i 71670 -i 72089
+	$(PYTHON) -m safety check --full-report -i 70612 -i 72089
 
 .PHONY: lint
 lint: fix-style check-safety

--- a/inseq/data/batch.py
+++ b/inseq/data/batch.py
@@ -27,6 +27,10 @@ class BatchEncoding(TensorWrapper):
     def __len__(self) -> int:
         return len(self.input_tokens)
 
+    @property
+    def num_sequences(self) -> int:
+        return self.input_ids.shape[0]
+
 
 @dataclass(eq=False, repr=False)
 class BatchEmbedding(TensorWrapper):


### PR DESCRIPTION
## Description

This PR fixes support for multi-EOS models (e.g. LLaMA 3.2, closes #287) and adds a new `clean_special_chars: bool = False` argument to `model.attribute` to support the cleaning of special characters from tokens in the `out.source` and `out.target` sequences using the native `tokenizer.decode` function provided by `transformers`.