### PR TITLE
Fix `MultiDimensional` attribution aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,17 @@ out_sliced = out.aggregate("slices", target_spans=(13,73))
 out_sliced = out[13:73]
 ```
 
+- A new `StringSplitAggregator` (`"split"`) is added to allow for supporting more complex aggregation procedures beyond simple subword merging  in`FeatureAttributionSequenceOutput` objects. More specifically, splitting supports regex expression to match split points even when these are (potentially overlapping) parts of existing tokens. The `split_mode` parameter can be set to `"single"` (default) to keep tokens containing matched split points separate while aggregating the rest, or `"start"` or `"end"` to concatenate them to the preceding/following aggregated token sequence. [#290](https://github.com/inseq-team/inseq/pull/290)
+
+```python
+# Split on newlines. Default split_mode = "single".
+out.aggregate("split", split_pattern="\n").aggregate("sum").show(do_aggregation=False)
+
+# Split on whitespace-separated words of length 5.
+# Note: this works if clean_special_chars = True is used, otherwise the split_pattern should be adjusted to split on special characters like "Ġ" or "▁".
+out.aggregate("split", split_pattern=r"\s(\w{5})(?=\s)", split_mode="end")
+```
+
 - The `__sub__` method in `FeatureAttributionSequenceOutput` is now used as a shortcut for `PairAggregator` ([#282](https://github.com/inseq-team/inseq/pull/282)).
 
 
@@ -89,6 +100,8 @@ out_female = attrib_model.attribute(
 - The directions of generated/attributed tokens were clarified in the visualization using arrows instead of x/y ([#282](https://github.com/inseq-team/inseq/pull/282)).
 
 - Fix support for multi-EOS tokens (e.g. LLaMA 3.2, see [#287](https://github.com/inseq-team/inseq/issues/287)).
+
+- Fix copying configuration parameters to aggregated `FeatureAttributionSequenceOutput` objects ([#292](https://github.com/inseq-team/inseq/pull/292)).
 
 ## 📝 Documentation and Tutorials
 

--- a/inseq/data/aggregator.py
+++ b/inseq/data/aggregator.py
@@ -300,7 +300,7 @@ class SequenceAttributionAggregator(Aggregator):
                     kwargs["aggregate_fn"] = kwargs["aggregate_fn"][cls.aggregator_family]
             field_func = getattr(cls, f"aggregate_{field}")
             aggregated_sequence_attribution_fields[field] = field_func(attr, **kwargs)
-        return attr.__class__(**aggregated_sequence_attribution_fields)
+        return attr.__class__(**aggregated_sequence_attribution_fields, **attr.config)
 
     @classmethod
     def _process_attribution_scores(
@@ -344,6 +344,12 @@ class SequenceAttributionAggregator(Aggregator):
     @classmethod
     def post_aggregate_hook(cls, attr: "FeatureAttributionSequenceOutput", **kwargs):
         super().post_aggregate_hook(attr, **kwargs)
+        if attr.source_attributions is not None:
+            attr._num_dimensions = attr.source_attributions.ndim
+        elif attr.target_attributions is not None:
+            attr._num_dimensions = attr.target_attributions.ndim
+        else:
+            attr._num_dimensions = 0
         cls.is_compatible(attr)
 
     @classmethod


### PR DESCRIPTION
## Description

This PR fixes the issue highlighted in #291 in which the information contained in configuration attributes (preceded by `_`) in `FeatureAttributionSequenceOutput` classes was not copied over after calling `out.aggregate`. This was causing methods like `value_zeroing` to break, since the default `MultiDimensionalFeatureAttributionSequenceOutput` output was assumed to be 4-dimensional from the `attention` method.

In the updated version, a new property `config` was added to `FeatureAttributionSequenceOutput` to easily access all configuration attributes, and the resulting properties are now updated correctly.