### PR TITLE
Fix CUDA OOB in ReAGent for tokenizers with special tokens past vocab_size

### DIFF
--- a/inseq/attr/feat/ops/reagent_core/token_sampler.py
+++ b/inseq/attr/feat/ops/reagent_core/token_sampler.py
@@ -57,7 +57,12 @@ class POSTagTokenSampler(TokenSampler):
             tokenizer=self.tokenizer,
         )
         num_postags = len(self.pos2ids)
-        self.id2pos = torch.zeros([self.tokenizer.vocab_size], dtype=torch.long, device=device)
+        # Size by ``len(tokenizer)`` rather than ``tokenizer.vocab_size`` so that special /
+        # added tokens (e.g. ``<|start_header_id|>`` in Llama 3.1, ``<|im_start|>`` in Qwen)
+        # whose ids exceed ``vocab_size`` still have a valid lookup slot and do not trigger a
+        # CUDA out-of-bounds in ``self.id2pos[input_ids]`` below. They map to pos index 0,
+        # so they get replaced by tokens from the first POS group during probing.
+        self.id2pos = torch.zeros([len(self.tokenizer)], dtype=torch.long, device=device)
         for pos_idx, ids in enumerate(self.pos2ids.values()):
             self.id2pos[ids] = pos_idx
         self.num_ids_per_pos = torch.tensor(


### PR DESCRIPTION
## Summary

Follow-up to #305 / #304 — addresses the second issue raised in https://github.com/inseq-team/inseq/issues/304#issuecomment by `@hxngu`: ReAGent still crashes with `CUDA error: device-side assert triggered` on Llama 3.1 (and Mistral / Qwen) when the input uses chat-template tokens.

## Root cause

`POSTagTokenSampler` sizes its `id2pos` lookup table by `tokenizer.vocab_size`:

```python
self.id2pos = torch.zeros([self.tokenizer.vocab_size], dtype=torch.long, device=device)
```

Modern chat-template tokenizers expose **added/special tokens whose ids exceed `vocab_size`**. For example:

| Model                    | `vocab_size` | `len(tokenizer)` | Special tokens beyond `vocab_size` |
|--------------------------|-------------:|-----------------:|------------------------------------|
| `Qwen/Qwen2.5-0.5B-Instruct` |       151643 |           151665 | `<\|im_start\|>=151644`, `<\|im_end\|>=151645`, … |
| `meta-llama/Llama-3.1-8B-Instruct` (per the report) |       128000 |           128256 | `<\|start_header_id\|>=128006`, `<\|end_header_id\|>=128007`, … |

When such an id appears in `input_ids`, `self.id2pos[input_ids]` (line 105) reads past the end of the tensor, triggering the device-side `Assertion '-sizes[i] <= index && index < sizes[i] && "index out of bounds"' failed`. The Python stack trace is misleading because the assert surfaces lazily during a later op (often inside `logging.debug` formatting of `mask_replacing`).

## Fix

Size `id2pos` by `len(tokenizer)` rather than `tokenizer.vocab_size`. Added tokens map to `pos=0` (the default-initialised value), so they are eligible for replacement by tokens from the first POS group during probing — acceptable, since chat-template / control tokens are rarely the locus of attribution interest.